### PR TITLE
#21 Add PR CI workflow for lint and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/src/ciWorkflow.test.ts
+++ b/src/ciWorkflow.test.ts
@@ -1,0 +1,24 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..");
+const workflowPath = join(root, ".github/workflows/ci.yml");
+
+describe("CI workflow contract", () => {
+  it("gates PRs with pnpm install, lint, test, and build", () => {
+    expect(existsSync(workflowPath)).toBe(true);
+    const yml = readFileSync(workflowPath, "utf8");
+    expect(yml).toMatch(/pull_request/);
+    expect(yml).toContain("pnpm/action-setup@v4");
+    expect(yml).toContain("version: 10");
+    expect(yml).toContain("actions/setup-node@v4");
+    expect(yml).toContain('cache: "pnpm"');
+    expect(yml).toContain("pnpm install --frozen-lockfile");
+    expect(yml).toContain("pnpm lint");
+    expect(yml).toContain("pnpm test");
+    expect(yml).toContain("pnpm build");
+  });
+});

--- a/src/ciWorkflow.test.ts
+++ b/src/ciWorkflow.test.ts
@@ -13,7 +13,10 @@ describe("CI workflow contract", () => {
     const yml = readFileSync(workflowPath, "utf8");
     expect(yml).toMatch(/pull_request/);
     expect(yml).toContain("pnpm/action-setup@v4");
-    expect(yml).toContain("version: 10");
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+      packageManager?: string;
+    };
+    expect(pkg.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+$/);
     expect(yml).toContain("actions/setup-node@v4");
     expect(yml).toContain('cache: "pnpm"');
     expect(yml).toContain("pnpm install --frozen-lockfile");

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,5 +21,11 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that runs on `pull_request` and pushes to `main`, using pnpm 10 with a frozen lockfile install, then `pnpm lint`, `pnpm test`, and `pnpm build`.

Includes a contract test (`src/ciWorkflow.test.ts`) that asserts the workflow file declares the expected steps and tooling (`pnpm/action-setup@v4`, `actions/setup-node@v4` with pnpm cache, `pull_request`, etc.).

`tsconfig.app.json` excludes Vitest files from the app TypeScript project so tests can use Node built-ins without widening `types` for the whole app bundle.

Closes #21

## Verification
```
pnpm install   # lockfile up to date, deps installed
pnpm test      # 2 files, 2 tests passed
pnpm lint      # eslint . — clean
pnpm build     # tsc -b && vite build — success
```