### PR TITLE
#22 Add deploy workflow to GitHub Pages on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/deployWorkflow.test.ts
+++ b/src/deployWorkflow.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..");
+const workflowPath = join(root, ".github/workflows/deploy.yml");
+const viteConfigPath = join(root, "vite.config.ts");
+
+describe("GitHub Pages deploy workflow contract", () => {
+  it("deploys main with pnpm build and official Pages actions", () => {
+    expect(existsSync(workflowPath)).toBe(true);
+    const yml = readFileSync(workflowPath, "utf8");
+    expect(yml).toMatch(/push:\s*\n(?:\s+.*\n)*?\s+branches:\s*\[?\s*['"]?main['"]?\s*\]?/m);
+    expect(yml).toContain("pnpm/action-setup@v4");
+    expect(yml).toContain("actions/setup-node@v4");
+    expect(yml).toContain("pnpm install --frozen-lockfile");
+    expect(yml).toContain("pnpm build");
+    expect(yml).toContain("actions/upload-pages-artifact");
+    expect(yml).toContain("actions/deploy-pages");
+    expect(yml).toMatch(/pages:\s*write/m);
+    expect(yml).toMatch(/id-token:\s*write/m);
+  });
+
+  it("sets Vite base for GitHub Pages project site", () => {
+    expect(existsSync(viteConfigPath)).toBe(true);
+    const ts = readFileSync(viteConfigPath, "utf8");
+    expect(ts).toContain("/the-aquarium/");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss()],
-});
+  base: command === "build" ? "/the-aquarium/" : "/",
+}));


### PR DESCRIPTION
Closes #22

## Summary
- Add `.github/workflows/deploy.yml` to build with pnpm on push to `main` (and `workflow_dispatch`), upload `dist` with `actions/upload-pages-artifact`, and deploy with `actions/deploy-pages`.
- Set Vite `base` to `/the-aquarium/` for production builds so assets resolve on the GitHub Pages project URL.
- Add contract tests for the deploy workflow and Vite base string.

## Manual setup (one-time)
In the repo on GitHub: **Settings → Pages → Build and deployment**, set **Source** to **GitHub Actions** (not “Deploy from a branch”). Until this is set, the workflow may not publish successfully.

## Verification
\`\`\`
pnpm install
# Lockfile is up to date, resolution step is skipped
# Already up to date
# Done in 461ms using pnpm v10.33.2

pnpm test
# Test Files  3 passed (3)
# Tests  4 passed (4)

pnpm lint
# (eslint completes with no errors)

pnpm build
# vite v8.0.10 building client environment for production...
# ✓ 16 modules transformed.
# dist/index.html                   0.50 kB │ gzip:  0.31 kB
# dist/assets/index-TSU16puK.css    6.46 kB │ gzip:  1.97 kB
# dist/assets/index-Bam8Q0oI.js   190.57 kB │ gzip: 60.03 kB
# ✓ built in 110ms
\`\`\`

Production `dist/index.html` references script and stylesheet under `/the-aquarium/`.