### PR TITLE
#3 Define base ECS entity types for fish and food

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@react-three/fiber": "^9.6.1",
+    "miniplex": "^2.0.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "three": "^0.184.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)
+      miniplex:
+        specifier: ^2.0.0
+        version: 2.0.0
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -270,6 +273,12 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@hmans/id@0.0.1':
+    resolution: {integrity: sha512-2BxHxZziST8F0P5Dt+UuttF2lwCaKK7QFR814PwEp708l6dm86pjWJAFr7BKyAGu27mRpYcghvCAUAucNdsCdw==}
+
+  '@hmans/queue@0.0.1':
+    resolution: {integrity: sha512-Mm8oQRFRoiEYQ3QD9CD14DTaShd21nzNrUFyBhFxy+TduKf2PdMRfHHx7lDvEpbODGNlj+e8mcWGj/YjWmC3Bw==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -305,6 +314,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@miniplex/bucket@2.0.0':
+    resolution: {integrity: sha512-jdAW0vG0tLel0dD0lyQqkQ4g4G9CscbVtenu35jB48fnVK3zmfFmQKIxXHsUvFs4KAN44UESAgaVOroTetFSRw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -897,6 +909,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventery@0.0.4:
+    resolution: {integrity: sha512-rQbXJG8WX9z2cm3IJadkSUZLWFXuwGMIJ40oWyB23DhVb1e92T7Jx3qF0UwtgHI7D4VZzVswbZ7MXfW88cFF4Q==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1144,6 +1159,9 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  miniplex@2.0.0:
+    resolution: {integrity: sha512-pJlxmlPf5Qyx12amgOCyRE6Lzw28ct2G0lF9xn7/xudLtA/xDOUnCIU2xOxCk8GkjePYctcNpjmFshJp/Ht66A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1738,6 +1756,10 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@hmans/id@0.0.1': {}
+
+  '@hmans/queue@0.0.1': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1772,6 +1794,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@miniplex/bucket@2.0.0':
+    dependencies:
+      eventery: 0.0.4
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2328,6 +2354,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventery@0.0.4: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2529,6 +2557,12 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  miniplex@2.0.0:
+    dependencies:
+      '@hmans/id': 0.0.1
+      '@hmans/queue': 0.0.1
+      '@miniplex/bucket': 2.0.0
 
   ms@2.1.3: {}
 

--- a/src/sim/entities.test.ts
+++ b/src/sim/entities.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  InvalidEntityShapeError,
+  assertFishEntityShape,
+  assertFoodEntityShape,
+  createSimulationWorld,
+  fishWithKinematics,
+  foodWithPosition,
+  registerFish,
+  registerFood,
+} from "./index";
+import type { FishEntity, FoodEntity, SimulationEntity } from "./index";
+
+const validFishPayload = {
+  fish: {
+    displayName: "Pebble",
+    hungerDays: 0,
+    health: 3 as const,
+    weightGrams: 100,
+    species: { kind: "herbivore" as const },
+  },
+  position: { x: 0, y: 0.5, z: 0 },
+  velocity: { x: 0, y: 0, z: 0 },
+};
+
+const validFoodPayload = {
+  food: { spawnedAtSimDays: 1.25 },
+  position: { x: 0.1, y: 0.4, z: 0 },
+};
+
+describe("simulation ECS entity shapes", () => {
+  it("accepts a complete fish payload and exposes it on a kinematics query", () => {
+    const world = createSimulationWorld();
+    const q = fishWithKinematics(world);
+    registerFish(world, validFishPayload);
+    const entities = [...q];
+    expect(entities).toHaveLength(1);
+    expect(entities[0]!.fish.displayName).toBe("Pebble");
+    expect(entities[0]!.position.y).toBe(0.5);
+  });
+
+  it("accepts a complete food payload and exposes it on a food query", () => {
+    const world = createSimulationWorld();
+    const q = foodWithPosition(world);
+    registerFood(world, validFoodPayload);
+    expect([...q]).toHaveLength(1);
+  });
+
+  it("rejects fish missing velocity with InvalidEntityShapeError", () => {
+    const bad = {
+      fish: validFishPayload.fish,
+      position: validFishPayload.position,
+    };
+    expect(() => assertFishEntityShape(bad)).toThrow(InvalidEntityShapeError);
+    try {
+      assertFishEntityShape(bad);
+    } catch (e) {
+      expect(e).toBeInstanceOf(InvalidEntityShapeError);
+      expect((e as InvalidEntityShapeError).issues.some((m) => m.includes("velocity"))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("rejects fish that incorrectly include food", () => {
+    const bad = { ...validFishPayload, food: { spawnedAtSimDays: 0 } };
+    expect(() => assertFishEntityShape(bad)).toThrow(InvalidEntityShapeError);
+  });
+
+  it("rejects food missing spawnedAtSimDays", () => {
+    const bad = {
+      food: {},
+      position: validFoodPayload.position,
+    };
+    expect(() => assertFoodEntityShape(bad)).toThrow(InvalidEntityShapeError);
+  });
+
+  it("rejects food that incorrectly include fish state", () => {
+    const bad = { ...validFoodPayload, fish: validFishPayload.fish };
+    expect(() => assertFoodEntityShape(bad)).toThrow(InvalidEntityShapeError);
+  });
+
+  it("rejects food that incorrectly include velocity", () => {
+    const bad = { ...validFoodPayload, velocity: { x: 0, y: 0, z: 0 } };
+    expect(() => assertFoodEntityShape(bad)).toThrow(InvalidEntityShapeError);
+  });
+
+  it("narrows fish query entities to fish + kinematics components", () => {
+    const world = createSimulationWorld();
+    const q = fishWithKinematics(world);
+    registerFish(world, validFishPayload);
+    const entity = [...q][0]!;
+    expectTypeOf(entity.fish).toMatchTypeOf(validFishPayload.fish);
+    expectTypeOf(entity.position).toMatchTypeOf(validFishPayload.position);
+    expectTypeOf(entity.velocity).toMatchTypeOf(validFishPayload.velocity);
+  });
+
+  it("keeps FishEntity and FoodEntity disjoint at the type level", () => {
+    expectTypeOf({} as FishEntity).not.toMatchTypeOf({} as FoodEntity);
+    expectTypeOf({} as SimulationEntity).toMatchTypeOf({} as FishEntity);
+    expectTypeOf({} as SimulationEntity).toMatchTypeOf({} as FoodEntity);
+  });
+});

--- a/src/sim/guards.ts
+++ b/src/sim/guards.ts
@@ -1,0 +1,189 @@
+import type { FishEntity, FishSpeciesTag, FishState, FoodEntity, FoodState, Vec3 } from "./types";
+
+export class InvalidEntityShapeError extends Error {
+  readonly issues: readonly string[];
+
+  constructor(issues: readonly string[]) {
+    super(issues.join("; "));
+    this.name = "InvalidEntityShapeError";
+    this.issues = issues;
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function issueVec3(path: string, v: unknown): string | null {
+  if (!isPlainRecord(v)) {
+    return `${path} must be an object with x, y, z numbers`;
+  }
+  for (const k of ["x", "y", "z"] as const) {
+    const n = v[k];
+    if (typeof n !== "number" || !Number.isFinite(n)) {
+      return `${path}.${k} must be a finite number`;
+    }
+  }
+  return null;
+}
+
+function parseVec3(path: string, v: unknown): Vec3 | null {
+  if (issueVec3(path, v)) {
+    return null;
+  }
+  const o = v as Record<string, unknown>;
+  return { x: o.x as number, y: o.y as number, z: o.z as number };
+}
+
+function parseSpecies(v: unknown): FishSpeciesTag | null {
+  if (!isPlainRecord(v) || v.kind === undefined) {
+    return null;
+  }
+  if (v.kind === "herbivore" || v.kind === "carnivore") {
+    return { kind: v.kind };
+  }
+  return null;
+}
+
+function collectFishState(path: string, v: unknown): { state: FishState } | { errors: string[] } {
+  const errors: string[] = [];
+  if (!isPlainRecord(v)) {
+    return { errors: [`${path} must be an object`] };
+  }
+  if (typeof v.displayName !== "string" || v.displayName.trim().length === 0) {
+    errors.push(`${path}.displayName must be a non-empty string`);
+  }
+  if (typeof v.hungerDays !== "number" || !Number.isFinite(v.hungerDays) || v.hungerDays < 0) {
+    errors.push(`${path}.hungerDays must be a finite number >= 0`);
+  }
+  const h = v.health;
+  if (
+    typeof h !== "number" ||
+    !Number.isInteger(h) ||
+    h < 0 ||
+    h > 3
+  ) {
+    errors.push(`${path}.health must be an integer in 0..3`);
+  }
+  if (typeof v.weightGrams !== "number" || !Number.isFinite(v.weightGrams) || v.weightGrams <= 0) {
+    errors.push(`${path}.weightGrams must be a finite number > 0`);
+  }
+  const species = parseSpecies(v.species);
+  if (!species) {
+    errors.push(`${path}.species must be { kind: "herbivore" } or { kind: "carnivore" }`);
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return {
+    state: {
+      displayName: v.displayName as string,
+      hungerDays: v.hungerDays as number,
+      health: h as 0 | 1 | 2 | 3,
+      weightGrams: v.weightGrams as number,
+      species: species as FishSpeciesTag,
+    },
+  };
+}
+
+/**
+ * Validates unknown input and returns a `FishEntity`, or throws `InvalidEntityShapeError`.
+ * Rejects extra `food` so fish and food archetypes stay disjoint at runtime.
+ */
+export function assertFishEntityShape(input: unknown): FishEntity {
+  const errors: string[] = [];
+  if (!isPlainRecord(input)) {
+    throw new InvalidEntityShapeError(["entity must be a plain object"]);
+  }
+  if ("food" in input && input.food !== undefined) {
+    errors.push("fish entity must not carry a food component");
+  }
+  for (const key of ["fish", "position", "velocity"] as const) {
+    if (!(key in input)) {
+      errors.push(`missing required property "${key}"`);
+    }
+  }
+  if (errors.length > 0) {
+    throw new InvalidEntityShapeError(errors);
+  }
+
+  const fishResult = collectFishState("fish", input.fish);
+  if ("errors" in fishResult) {
+    throw new InvalidEntityShapeError(fishResult.errors);
+  }
+
+  const pos = parseVec3("position", input.position);
+  const vel = parseVec3("velocity", input.velocity);
+  if (!pos) {
+    errors.push(issueVec3("position", input.position)!);
+  }
+  if (!vel) {
+    errors.push(issueVec3("velocity", input.velocity)!);
+  }
+  if (errors.length > 0) {
+    throw new InvalidEntityShapeError(errors);
+  }
+
+  return {
+    fish: fishResult.state,
+    position: pos!,
+    velocity: vel!,
+  };
+}
+
+function collectFoodState(path: string, v: unknown): { state: FoodState } | { errors: string[] } {
+  const errors: string[] = [];
+  if (!isPlainRecord(v)) {
+    return { errors: [`${path} must be an object`] };
+  }
+  if (
+    typeof v.spawnedAtSimDays !== "number" ||
+    !Number.isFinite(v.spawnedAtSimDays)
+  ) {
+    errors.push(`${path}.spawnedAtSimDays must be a finite number`);
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { state: { spawnedAtSimDays: v.spawnedAtSimDays as number } };
+}
+
+/**
+ * Validates unknown input and returns a `FoodEntity`, or throws `InvalidEntityShapeError`.
+ * Rejects `fish` / `velocity` so flakes stay distinct from fish archetypes.
+ */
+export function assertFoodEntityShape(input: unknown): FoodEntity {
+  const errors: string[] = [];
+  if (!isPlainRecord(input)) {
+    throw new InvalidEntityShapeError(["entity must be a plain object"]);
+  }
+  if ("fish" in input && input.fish !== undefined) {
+    errors.push("food entity must not carry a fish component");
+  }
+  if ("velocity" in input && input.velocity !== undefined) {
+    errors.push("food entity must not carry velocity");
+  }
+  for (const key of ["food", "position"] as const) {
+    if (!(key in input)) {
+      errors.push(`missing required property "${key}"`);
+    }
+  }
+  if (errors.length > 0) {
+    throw new InvalidEntityShapeError(errors);
+  }
+
+  const foodResult = collectFoodState("food", input.food);
+  if ("errors" in foodResult) {
+    throw new InvalidEntityShapeError(foodResult.errors);
+  }
+
+  const pos = parseVec3("position", input.position);
+  if (!pos) {
+    throw new InvalidEntityShapeError([issueVec3("position", input.position)!]);
+  }
+
+  return {
+    food: foodResult.state,
+    position: pos,
+  };
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -1,0 +1,18 @@
+export type {
+  FishEntity,
+  FishSpeciesTag,
+  FishState,
+  FoodEntity,
+  FoodState,
+  SimulationEntity,
+  Vec3,
+} from "./types";
+export { InvalidEntityShapeError, assertFishEntityShape, assertFoodEntityShape } from "./guards";
+export {
+  createSimulationWorld,
+  fishWithKinematics,
+  foodWithPosition,
+  registerFish,
+  registerFood,
+} from "./world";
+export type { FishKinematicsEntity, FoodPositionEntity } from "./world";

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1,0 +1,50 @@
+/** Tank-space vector used by fish and food. */
+export type Vec3 = { x: number; y: number; z: number };
+
+export type FishSpeciesTag = { kind: "herbivore" } | { kind: "carnivore" };
+
+/**
+ * Fish-only simulation fields (movement uses shared `position` / `velocity`).
+ * Hunger and health align with `docs/the-game.md` (health 0–3, per-fish hunger clock).
+ */
+export type FishState = {
+  displayName: string;
+  /** Days since last meal; 0 means just ate. */
+  hungerDays: number;
+  health: 0 | 1 | 2 | 3;
+  weightGrams: number;
+  species: FishSpeciesTag;
+};
+
+/**
+ * Strict fish archetype: always has kinematics + `fish` state.
+ * (Miniplex `World` uses one component record; `SimulationEntity` is the widened bag.)
+ */
+export type FishEntity = {
+  fish: FishState;
+  position: Vec3;
+  velocity: Vec3;
+};
+
+/** Food flake metadata (decay uses spawn time vs sim days). */
+export type FoodState = {
+  spawnedAtSimDays: number;
+};
+
+/** Strict food archetype: positioned flake with no velocity. */
+export type FoodEntity = {
+  food: FoodState;
+  position: Vec3;
+};
+
+/**
+ * Component superset stored in the Miniplex world. Fish carry `fish` + `velocity`;
+ * food carries `food` only (guards reject `velocity` on flakes). `keyof` must list
+ * every component name so `.with("fish", …)` type-checks.
+ */
+export type SimulationEntity = {
+  position: Vec3;
+  velocity?: Vec3;
+  fish?: FishState;
+  food?: FoodState;
+};

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -1,0 +1,32 @@
+import { World, type With } from "miniplex";
+import type { FishEntity, FoodEntity, SimulationEntity } from "./types";
+import { assertFishEntityShape, assertFoodEntityShape } from "./guards";
+
+export function createSimulationWorld(entities: SimulationEntity[] = []): World<SimulationEntity> {
+  return new World<SimulationEntity>(entities);
+}
+
+export function registerFish(world: World<SimulationEntity>, candidate: unknown): FishEntity {
+  const fish = assertFishEntityShape(candidate);
+  world.add(fish);
+  return fish;
+}
+
+export function registerFood(world: World<SimulationEntity>, candidate: unknown): FoodEntity {
+  const food = assertFoodEntityShape(candidate);
+  world.add(food);
+  return food;
+}
+
+/** Fish that can participate in movement / targeting systems. */
+export function fishWithKinematics(world: World<SimulationEntity>) {
+  return world.with("fish", "position", "velocity").connect();
+}
+
+/** Food flakes positioned in the tank. */
+export function foodWithPosition(world: World<SimulationEntity>) {
+  return world.with("food", "position").connect();
+}
+
+export type FishKinematicsEntity = With<SimulationEntity, "fish" | "position" | "velocity">;
+export type FoodPositionEntity = With<SimulationEntity, "food" | "position">;


### PR DESCRIPTION
Closes #3

## Summary
- Add `miniplex` and a typed `src/sim/` layer: `SimulationEntity` component bag, strict `FishEntity` / `FoodEntity` shapes, spawn guards (`assertFishEntityShape` / `assertFoodEntityShape`), and `createSimulationWorld` with query helpers for fish kinematics and food position.
- Vitest covers valid fish/food registration plus runtime rejection of invalid partials and disjoint archetypes.

## Verification
```text
$ pnpm install
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 276ms using pnpm v10.33.2

$ pnpm test
Test Files  5 passed (5)
Tests  18 passed (18)

$ pnpm lint
eslint . (no issues)

$ pnpm build
tsc -b && vite build — succeeded (Vite chunk size warning only)
```