### PR TITLE
#16 Add pause toggle to freeze simulation updates

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import App from "./App";
 
@@ -16,5 +16,14 @@ describe("App shell", () => {
     const { container } = render(<App />);
     expect(screen.getByTestId("tank-scene-root")).toBeTruthy();
     expect(container.querySelector("canvas")).toBeTruthy();
+  });
+
+  it("shows paused status after toggling pause and hides it on resume", () => {
+    render(<App />);
+    expect(screen.queryByRole("status", { name: /simulation paused/i })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /pause simulation/i }));
+    expect(screen.getByRole("status", { name: /simulation paused/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /resume simulation/i }));
+    expect(screen.queryByRole("status", { name: /simulation paused/i })).toBeNull();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,43 @@
+import { SimulationClockProvider } from "./game/SimulationClockProvider";
+import { useSimulationClock } from "./game/simulationClockContext";
 import { TankScene } from "./tank/TankScene";
 
-export default function App() {
+function GameShell() {
+  const { paused, togglePause } = useSimulationClock();
   return (
     <div className="relative flex min-h-dvh flex-col">
-      <TankScene className="min-h-dvh w-full flex-1" />
+      <div className="pointer-events-auto absolute top-4 right-4 z-20 flex flex-col items-end gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium text-neutral-100 shadow-sm backdrop-blur-sm hover:bg-neutral-800"
+          aria-pressed={paused}
+          onClick={togglePause}
+        >
+          {paused ? "Resume simulation" : "Pause simulation"}
+        </button>
+        {paused ? (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-label="Simulation paused"
+            className="rounded-md border border-amber-700/80 bg-amber-950/95 px-3 py-2 text-sm font-semibold tracking-wide text-amber-100 shadow-md"
+          >
+            Paused — world progression is frozen
+          </div>
+        ) : null}
+      </div>
+      <TankScene className="min-h-dvh w-full flex-1" paused={paused} />
       <p className="pointer-events-none absolute bottom-6 left-1/2 -translate-x-1/2 text-sm text-neutral-400 drop-shadow-sm">
         The Aquarium
       </p>
     </div>
+  );
+}
+
+export default function App() {
+  return (
+    <SimulationClockProvider>
+      <GameShell />
+    </SimulationClockProvider>
   );
 }

--- a/src/game/SimulationClockProvider.tsx
+++ b/src/game/SimulationClockProvider.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { advanceClockByWallDelta, togglePause, type SimulationClockState } from "../sim/simulationClock";
+import { SimulationClockContext, type SimulationClockContextValue } from "./simulationClockContext";
+
+const initialClock: SimulationClockState = { paused: false, simDays: 0 };
+
+export function SimulationClockProvider({ children }: { children: ReactNode }) {
+  const [clock, setClock] = useState<SimulationClockState>(initialClock);
+
+  const advanceByWallDelta = useCallback((deltaWallSeconds: number) => {
+    setClock((c) => advanceClockByWallDelta(c, deltaWallSeconds));
+  }, []);
+
+  const handleTogglePause = useCallback(() => {
+    setClock((c) => togglePause(c));
+  }, []);
+
+  const value = useMemo(
+    (): SimulationClockContextValue => ({
+      paused: clock.paused,
+      simDays: clock.simDays,
+      togglePause: handleTogglePause,
+      advanceByWallDelta,
+    }),
+    [clock.paused, clock.simDays, handleTogglePause, advanceByWallDelta],
+  );
+
+  return <SimulationClockContext.Provider value={value}>{children}</SimulationClockContext.Provider>;
+}

--- a/src/game/simulationClockContext.ts
+++ b/src/game/simulationClockContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+export type SimulationClockContextValue = {
+  paused: boolean;
+  simDays: number;
+  togglePause: () => void;
+  advanceByWallDelta: (deltaWallSeconds: number) => void;
+};
+
+export const SimulationClockContext = createContext<SimulationClockContextValue | null>(null);
+
+export function useSimulationClock(): SimulationClockContextValue {
+  const ctx = useContext(SimulationClockContext);
+  if (!ctx) {
+    throw new Error("useSimulationClock must be used within SimulationClockProvider");
+  }
+  return ctx;
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -16,3 +16,13 @@ export {
   registerFood,
 } from "./world";
 export type { FishKinematicsEntity, FoodPositionEntity } from "./world";
+export {
+  MAX_WALL_DELTA_SECONDS_PER_STEP,
+  WALL_SECONDS_PER_SIM_DAY,
+  advanceClockByWallDelta,
+  clampWallDeltaSeconds,
+  setPaused,
+  togglePause,
+  wallDeltaToSimDays,
+} from "./simulationClock";
+export type { SimulationClockState } from "./simulationClock";

--- a/src/sim/simulationClock.test.ts
+++ b/src/sim/simulationClock.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_WALL_DELTA_SECONDS_PER_STEP,
+  WALL_SECONDS_PER_SIM_DAY,
+  advanceClockByWallDelta,
+  clampWallDeltaSeconds,
+  setPaused,
+  togglePause,
+  wallDeltaToSimDays,
+  type SimulationClockState,
+} from "./simulationClock";
+
+describe("simulationClock", () => {
+  const running: SimulationClockState = { paused: false, simDays: 0 };
+  const paused: SimulationClockState = { paused: true, simDays: 2 };
+
+  it("advances simDays by wall delta when not paused (respects per-step clamp)", () => {
+    const wallDt = 0.1;
+    const next = advanceClockByWallDelta(running, wallDt);
+    expect(next.paused).toBe(false);
+    expect(next.simDays).toBeCloseTo(wallDt / WALL_SECONDS_PER_SIM_DAY, 5);
+  });
+
+  it("does not advance simDays while paused", () => {
+    const next = advanceClockByWallDelta(paused, WALL_SECONDS_PER_SIM_DAY * 10);
+    expect(next).toEqual(paused);
+  });
+
+  it("resumes advancing from the same simDays after unpause", () => {
+    const wallDt = 0.2;
+    const mid = advanceClockByWallDelta(running, wallDt);
+    expect(mid.simDays).toBeCloseTo(wallDt / WALL_SECONDS_PER_SIM_DAY, 5);
+    const frozen = setPaused(mid, true);
+    const still = advanceClockByWallDelta(frozen, wallDt * 50);
+    expect(still.simDays).toBeCloseTo(mid.simDays, 5);
+    const thawed = setPaused(still, false);
+    const after = advanceClockByWallDelta(thawed, wallDt);
+    expect(after.simDays).toBeCloseTo((2 * wallDt) / WALL_SECONDS_PER_SIM_DAY, 5);
+  });
+
+  it("clamps large wall deltas before converting to sim days", () => {
+    expect(clampWallDeltaSeconds(999)).toBe(MAX_WALL_DELTA_SECONDS_PER_STEP);
+    expect(wallDeltaToSimDays(999)).toBe(
+      MAX_WALL_DELTA_SECONDS_PER_STEP / WALL_SECONDS_PER_SIM_DAY,
+    );
+  });
+
+  it("togglePause flips paused flag without changing simDays", () => {
+    const t = togglePause(running);
+    expect(t).toEqual({ paused: true, simDays: 0 });
+    expect(togglePause(t)).toEqual({ paused: false, simDays: 0 });
+  });
+});

--- a/src/sim/simulationClock.ts
+++ b/src/sim/simulationClock.ts
@@ -1,0 +1,40 @@
+/**
+ * Wall-clock ↔ in-game day conversion at default speed (see docs/the-game.md).
+ * Simulation progression uses this mapping from frame deltas.
+ */
+export const WALL_SECONDS_PER_SIM_DAY = 6.5;
+
+/** Max wall seconds applied per step to avoid huge leaps after stalls (implementation-decisions.md). */
+export const MAX_WALL_DELTA_SECONDS_PER_STEP = 0.25;
+
+export type SimulationClockState = {
+  paused: boolean;
+  simDays: number;
+};
+
+export function clampWallDeltaSeconds(deltaWallSeconds: number): number {
+  if (deltaWallSeconds <= 0) return 0;
+  return Math.min(deltaWallSeconds, MAX_WALL_DELTA_SECONDS_PER_STEP);
+}
+
+export function wallDeltaToSimDays(deltaWallSeconds: number): number {
+  return clampWallDeltaSeconds(deltaWallSeconds) / WALL_SECONDS_PER_SIM_DAY;
+}
+
+export function advanceClockByWallDelta(
+  clock: SimulationClockState,
+  deltaWallSeconds: number,
+): SimulationClockState {
+  if (clock.paused) return clock;
+  const simDays = clock.simDays + wallDeltaToSimDays(deltaWallSeconds);
+  return { ...clock, simDays };
+}
+
+export function togglePause(clock: SimulationClockState): SimulationClockState {
+  return { ...clock, paused: !clock.paused };
+}
+
+export function setPaused(clock: SimulationClockState, paused: boolean): SimulationClockState {
+  if (clock.paused === paused) return clock;
+  return { ...clock, paused };
+}

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -1,0 +1,15 @@
+import { useFrame } from "@react-three/fiber";
+import { useSimulationClock } from "../game/simulationClockContext";
+
+/**
+ * Maps the R3F frame loop to simulation clock advances. Paused mode stops the
+ * canvas frameloop, so this hook does not run while paused.
+ */
+export function SimulationFrameBridge() {
+  const { paused, advanceByWallDelta } = useSimulationClock();
+  useFrame((_, delta) => {
+    if (paused) return;
+    advanceByWallDelta(delta);
+  });
+  return null;
+}

--- a/src/tank/TankScene.tsx
+++ b/src/tank/TankScene.tsx
@@ -8,18 +8,24 @@ import {
   TANK_FLOOR_Y,
   TANK_SCENE_BACKGROUND,
 } from "./tankCameraConstants";
+import { SimulationFrameBridge } from "./SimulationFrameBridge";
 
 const sceneBackground = new Color(TANK_SCENE_BACKGROUND);
 
 export type TankSceneProps = {
   className?: string;
+  /** When true, stops the render loop so the tank and simulation clock stay frozen. */
+  paused?: boolean;
 };
 
-export function TankScene({ className }: TankSceneProps) {
+export function TankScene({ className, paused = false }: TankSceneProps) {
+  const frameloop = paused ? "never" : "always";
+  const rootClass = [className, paused ? "pointer-events-none" : ""].filter(Boolean).join(" ");
   return (
-    <div className={className} data-testid="tank-scene-root">
+    <div className={rootClass} data-testid="tank-scene-root">
       <Canvas
         className="h-full w-full touch-none"
+        frameloop={frameloop}
         gl={{ antialias: true, alpha: false }}
         camera={{
           position: TANK_CAMERA_POSITION,
@@ -31,6 +37,7 @@ export function TankScene({ className }: TankSceneProps) {
           scene.background = sceneBackground;
         }}
       >
+        <SimulationFrameBridge />
         <ambientLight intensity={0.55} />
         <directionalLight position={[4, 6, 3]} intensity={0.85} />
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, TANK_FLOOR_Y, 0]}>


### PR DESCRIPTION
## Linked issue

Closes https://github.com/Michael-F-Bryan/the-aquarium/issues/16

## Summary

- Add pure `simulationClock` helpers (pause, clamped wall→sim-day steps) and unit tests.
- Wire `SimulationClockProvider` + `SimulationFrameBridge` so sim time advances only while unpaused; R3F `frameloop=\"never\"` while paused freezes the render loop.
- HUD: Pause/Resume control, live `role=\"status\"` banner when paused, `pointer-events-none` on the tank while paused so future tank input does not fire.

## Verification

### `pnpm test`

```
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-16-pause-toggle
> vitest run


 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-16-pause-toggle


 Test Files  6 passed (6)
      Tests  24 passed (24)
   Start at  21:54:35
   Duration  1.47s (transform 270ms, setup 218ms, import 366ms, tests 122ms, environment 5.61s)
```

### `pnpm lint`

```
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-16-pause-toggle
> eslint .
```

### `pnpm build`

```
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-16-pause-toggle
> tsc -b && vite build

vite v8.0.10 building client environment for production...
✓ 35 modules transformed.
dist/index.html                     0.50 kB │ gzip:   0.30 kB
dist/assets/index-oFmXUBWy.css     13.26 kB │ gzip:   3.20 kB
dist/assets/index-CqdEp8rC.js   1,073.42 kB │ gzip: 295.09 kB

✓ built in 244ms
[plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use `build.rolldownOptions.output.codeSplitting` to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via `build.chunkSizeWarningLimit`.
```

## Follow-ups

None for this issue scope.