### PR TITLE
#15 Add day counter tick in HUD

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,6 +18,11 @@ describe("App shell", () => {
     expect(container.querySelector("canvas")).toBeTruthy();
   });
 
+  it("shows the simulation day counter in the HUD", () => {
+    render(<App />);
+    expect(screen.getByRole("status", { name: /current simulation day,\s*1/i })).toBeTruthy();
+  });
+
   it("shows paused status after toggling pause and hides it on resume", () => {
     render(<App />);
     expect(screen.queryByRole("status", { name: /simulation paused/i })).toBeNull();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { SimulationClockProvider } from "./game/SimulationClockProvider";
 import { useSimulationClock } from "./game/simulationClockContext";
 import { TankScene } from "./tank/TankScene";
+import { DayCounter } from "./ui/DayCounter";
 
 function GameShell() {
   const { paused, togglePause } = useSimulationClock();
   return (
     <div className="relative flex min-h-dvh flex-col">
       <div className="pointer-events-auto absolute top-4 right-4 z-20 flex flex-col items-end gap-2">
+        <DayCounter />
         <button
           type="button"
           className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium text-neutral-100 shadow-sm backdrop-blur-sm hover:bg-neutral-800"

--- a/src/ui/DayCounter.test.tsx
+++ b/src/ui/DayCounter.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SimulationClockProvider } from "../game/SimulationClockProvider";
+import { useSimulationClock } from "../game/simulationClockContext";
+import {
+  MAX_WALL_DELTA_SECONDS_PER_STEP,
+  WALL_SECONDS_PER_SIM_DAY,
+} from "../sim/simulationClock";
+import { DayCounter } from "./DayCounter";
+
+afterEach(() => {
+  cleanup();
+});
+
+/** One `advanceByWallDelta` applies at most `MAX_WALL_DELTA_SECONDS_PER_STEP` (see simulationClock). */
+const ADVANCE_CLICKS_PER_SIM_DAY = Math.ceil(
+  WALL_SECONDS_PER_SIM_DAY / MAX_WALL_DELTA_SECONDS_PER_STEP,
+);
+
+function DayCounterHarness() {
+  const { advanceByWallDelta, togglePause } = useSimulationClock();
+  return (
+    <>
+      <DayCounter />
+      <button
+        type="button"
+        aria-label="Advance one full simulation day"
+        onClick={() => {
+          for (let i = 0; i < ADVANCE_CLICKS_PER_SIM_DAY; i++) {
+            advanceByWallDelta(WALL_SECONDS_PER_SIM_DAY);
+          }
+        }}
+      />
+      <button type="button" aria-label="Toggle pause" onClick={togglePause} />
+    </>
+  );
+}
+
+function renderWithClock() {
+  return render(
+    <SimulationClockProvider>
+      <DayCounterHarness />
+    </SimulationClockProvider>,
+  );
+}
+
+describe("DayCounter", () => {
+  it("shows day 1 at the start of a new simulation", () => {
+    renderWithClock();
+    expect(screen.getByRole("status", { name: /current simulation day,\s*1/i })).toBeTruthy();
+  });
+
+  it("increments the displayed day when the simulation clock advances", () => {
+    renderWithClock();
+    fireEvent.click(screen.getByRole("button", { name: /advance one full simulation day/i }));
+    expect(screen.getByRole("status", { name: /current simulation day,\s*2/i })).toBeTruthy();
+  });
+
+  it("does not advance the displayed day while the simulation is paused", () => {
+    renderWithClock();
+    fireEvent.click(screen.getByRole("button", { name: /advance one full simulation day/i }));
+    expect(screen.getByRole("status", { name: /current simulation day,\s*2/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /toggle pause/i }));
+    fireEvent.click(screen.getByRole("button", { name: /advance one full simulation day/i }));
+    expect(screen.getByRole("status", { name: /current simulation day,\s*2/i })).toBeTruthy();
+  });
+
+  it("resumes advancing the displayed day after unpause", () => {
+    renderWithClock();
+    fireEvent.click(screen.getByRole("button", { name: /advance one full simulation day/i }));
+    fireEvent.click(screen.getByRole("button", { name: /toggle pause/i }));
+    fireEvent.click(screen.getByRole("button", { name: /advance one full simulation day/i }));
+    fireEvent.click(screen.getByRole("button", { name: /toggle pause/i }));
+    fireEvent.click(screen.getByRole("button", { name: /advance one full simulation day/i }));
+    expect(screen.getByRole("status", { name: /current simulation day,\s*3/i })).toBeTruthy();
+  });
+});

--- a/src/ui/DayCounter.tsx
+++ b/src/ui/DayCounter.tsx
@@ -1,0 +1,21 @@
+import { useSimulationClock } from "../game/simulationClockContext";
+
+function calendarDayFromSimDays(simDays: number): number {
+  // Guard against float dust (e.g. 26 × 0.25/6.5) landing just below the next integer.
+  return Math.floor(simDays + 1e-9) + 1;
+}
+
+export function DayCounter() {
+  const { simDays } = useSimulationClock();
+  const day = calendarDayFromSimDays(simDays);
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={`Current simulation day, ${day}`}
+      className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium tabular-nums tracking-wide text-neutral-100 shadow-sm backdrop-blur-sm"
+    >
+      Day {day}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #15

## Summary
- Add `DayCounter` HUD control that reads `simDays` from `useSimulationClock()` (same time base as the frame bridge; no duplicate pacing constants).
- Display uses `Math.floor(simDays + 1e-9) + 1` so stacked max-clamp advances still roll to the next day under floating-point (matches `MAX_WALL_DELTA_SECONDS_PER_STEP` behavior).
- Tests cover initial day, advance, freeze while paused, resume after unpause; `App.test` asserts the counter is present in the shell.

## Verification
```text
$ pnpm test

 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-15-day-counter

 Test Files  7 passed (7)
      Tests  29 passed (29)

$ pnpm lint

> the-aquarium@0.0.0 lint
> eslint .

$ pnpm build

> the-aquarium@0.0.0 build
> tsc -b && vite build

✓ built in 293ms
```