### PR TITLE
#17 Add toast log shell component

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -23,6 +23,11 @@ describe("App shell", () => {
     expect(screen.getByRole("status", { name: /current simulation day,\s*1/i })).toBeTruthy();
   });
 
+  it("shows the toast log panel in the HUD", () => {
+    render(<App />);
+    expect(screen.getByRole("log", { name: /event log/i })).toBeTruthy();
+  });
+
   it("shows paused status after toggling pause and hides it on resume", () => {
     render(<App />);
     expect(screen.queryByRole("status", { name: /simulation paused/i })).toBeNull();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { SimulationClockProvider } from "./game/SimulationClockProvider";
 import { useSimulationClock } from "./game/simulationClockContext";
 import { TankScene } from "./tank/TankScene";
 import { DayCounter } from "./ui/DayCounter";
+import { ToastLogShell } from "./ui/ToastLogShell";
 
 function GameShell() {
   const { paused, togglePause } = useSimulationClock();
@@ -9,6 +10,7 @@ function GameShell() {
     <div className="relative flex min-h-dvh flex-col">
       <div className="pointer-events-auto absolute top-4 right-4 z-20 flex flex-col items-end gap-2">
         <DayCounter />
+        <ToastLogShell entries={[]} />
         <button
           type="button"
           className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium text-neutral-100 shadow-sm backdrop-blur-sm hover:bg-neutral-800"

--- a/src/ui/ToastLogShell.test.tsx
+++ b/src/ui/ToastLogShell.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ToastLogShell } from "./ToastLogShell";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToastLogShell", () => {
+  it("renders a toast log panel for HUD use", () => {
+    render(<ToastLogShell entries={[]} />);
+    expect(screen.getByRole("log", { name: /event log/i })).toBeTruthy();
+  });
+
+  it("lists entries in append order (oldest first, newest last)", () => {
+    render(
+      <ToastLogShell
+        entries={[
+          { id: "1", message: "First toast" },
+          { id: "2", message: "Second toast" },
+          { id: "3", message: "Third toast" },
+        ]}
+      />,
+    );
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(3);
+    expect(rows[0]?.textContent).toContain("First toast");
+    expect(rows[1]?.textContent).toContain("Second toast");
+    expect(rows[2]?.textContent).toContain("Third toast");
+  });
+
+  it("uses a scrollable container so overflow is handled gracefully", () => {
+    render(<ToastLogShell entries={[]} />);
+    const log = screen.getByRole("log", { name: /event log/i });
+    const classes = log.className;
+    expect(classes.includes("max-h-48")).toBe(true);
+    expect(classes.includes("overflow-y-auto")).toBe(true);
+  });
+});

--- a/src/ui/ToastLogShell.tsx
+++ b/src/ui/ToastLogShell.tsx
@@ -1,0 +1,34 @@
+export type ToastLogEntry = {
+  id: string;
+  message: string;
+};
+
+type ToastLogShellProps = {
+  entries: readonly ToastLogEntry[];
+};
+
+/**
+ * Read-only toast list shell for the HUD. Simulation code will append entries later;
+ * this component only renders the provided list in order inside a capped, scrollable region.
+ */
+export function ToastLogShell({ entries }: ToastLogShellProps) {
+  return (
+    <div className="w-full max-w-xs rounded-md border border-neutral-600 bg-neutral-900/90 shadow-sm backdrop-blur-sm">
+      <div
+        role="log"
+        aria-label="Event log"
+        aria-live="polite"
+        aria-relevant="additions"
+        className="max-h-48 overflow-y-auto px-3 py-2 text-left text-sm text-neutral-100"
+      >
+        <ol className="m-0 flex list-none flex-col gap-1.5 p-0">
+          {entries.map((entry) => (
+            <li key={entry.id} className="break-words leading-snug">
+              {entry.message}
+            </li>
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #17

## Summary
- Add `ToastLogShell` HUD component: ordered list of `ToastLogEntry` items, `role="log"` + live region for future hunger/death toasts.
- Cap height (`max-h-48`) with `overflow-y-auto` so long logs scroll instead of covering the tank.
- Mount empty shell in `GameShell` beside existing HUD controls.

## Definition of done
- [x] Toast panel renders in HUD layout.
- [x] New entries append in order (array order → DOM order).
- [x] Panel handles overflow gracefully (scrollable region).

## Verification

\`\`\`
$ pnpm test

> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-17-toast-shell
> vitest run

 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-17-toast-shell

 Test Files  8 passed (8)
      Tests  33 passed (33)
   Start at  22:05:14
   Duration  1.66s (transform 550ms, setup 302ms, import 782ms, tests 351ms, environment 7.59s)

$ pnpm lint

> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-17-toast-shell
> eslint .

$ pnpm build

> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-17-toast-shell
> tsc -b && vite build

vite v8.0.10 building client environment for production...
transforming...✓ 37 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.30 kB
dist/assets/index-D1o75dfz.css     14.39 kB │ gzip:   3.46 kB
dist/assets/index-By6442dg.js   1,074.38 kB │ gzip: 295.35 kB

✓ built in 252ms
[plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
\`\`\`