### PR TITLE
#18 Add score placeholder component in HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { SimulationClockProvider } from "./game/SimulationClockProvider";
 import { useSimulationClock } from "./game/simulationClockContext";
 import { TankScene } from "./tank/TankScene";
 import { DayCounter } from "./ui/DayCounter";
+import { ScorePlaceholder } from "./ui/ScorePlaceholder";
 import { ToastLogShell } from "./ui/ToastLogShell";
 
 function GameShell() {
@@ -10,6 +11,7 @@ function GameShell() {
     <div className="relative flex min-h-dvh flex-col">
       <div className="pointer-events-auto absolute top-4 right-4 z-20 flex flex-col items-end gap-2">
         <DayCounter />
+        <ScorePlaceholder />
         <ToastLogShell entries={[]} />
         <button
           type="button"

--- a/src/ui/ScorePlaceholder.test.tsx
+++ b/src/ui/ScorePlaceholder.test.tsx
@@ -1,0 +1,16 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ScorePlaceholder } from "./ScorePlaceholder";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ScorePlaceholder", () => {
+  it("renders the score label and a placeholder value without a simulation provider", () => {
+    render(<ScorePlaceholder />);
+    const region = screen.getByRole("status", { name: /score/i });
+    expect(region.textContent).toMatch(/Score/i);
+    expect(region.textContent).toContain("—");
+  });
+});

--- a/src/ui/ScorePlaceholder.tsx
+++ b/src/ui/ScorePlaceholder.tsx
@@ -1,0 +1,16 @@
+/**
+ * HUD slot for score. Displays static placeholder text until scoring ships in a later release.
+ */
+export function ScorePlaceholder() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Score placeholder"
+      className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium tabular-nums tracking-wide text-neutral-100 shadow-sm backdrop-blur-sm"
+    >
+      <span className="text-neutral-300">Score</span>
+      <span className="ml-2 font-semibold text-neutral-100">—</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `ScorePlaceholder` in the top-right HUD stack (below `DayCounter`, above `ToastLogShell`) with static **Score** label and **—** value.
- No imports from `src/sim` or `useSimulationClock`; component is presentation-only for later scoring.

Closes #18

## Verification

```
pnpm test
 RUN  v4.1.5
 Test Files  9 passed (9)
      Tests  34 passed (34)

pnpm lint
> eslint .

pnpm build
✓ built in 242ms
```

(Initial baseline after `pnpm install` on this branch: 8 files / 33 tests — all green.)