### PR TITLE
#4 Add single starter fish spawn on new run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { SimulationClockProvider } from "./game/SimulationClockProvider";
+import { SimulationWorldProvider } from "./game/SimulationWorldProvider";
 import { useSimulationClock } from "./game/simulationClockContext";
 import { TankScene } from "./tank/TankScene";
 import { DayCounter } from "./ui/DayCounter";
@@ -43,7 +44,9 @@ function GameShell() {
 export default function App() {
   return (
     <SimulationClockProvider>
-      <GameShell />
+      <SimulationWorldProvider>
+        <GameShell />
+      </SimulationWorldProvider>
     </SimulationClockProvider>
   );
 }

--- a/src/game/SimulationWorldProvider.tsx
+++ b/src/game/SimulationWorldProvider.tsx
@@ -1,0 +1,20 @@
+import { useMemo, type ReactNode } from "react";
+import type { World } from "miniplex";
+import type { SimulationEntity } from "../sim/types";
+import { createNewRunSimulationWorld, DEFAULT_SIMULATION_SEED } from "../sim/newRunWorld";
+import { SimulationWorldContext } from "./simulationWorldContext";
+
+export type SimulationWorldProviderProps = {
+  children: ReactNode;
+  /** Simulation RNG / starter baseline; default is deterministic across loads. */
+  runSeed?: number;
+};
+
+export function SimulationWorldProvider({ children, runSeed = DEFAULT_SIMULATION_SEED }: SimulationWorldProviderProps) {
+  const value = useMemo((): { world: World<SimulationEntity>; runSeed: number } => {
+    const world = createNewRunSimulationWorld(runSeed);
+    return { world, runSeed };
+  }, [runSeed]);
+
+  return <SimulationWorldContext.Provider value={value}>{children}</SimulationWorldContext.Provider>;
+}

--- a/src/game/simulationWorldContext.ts
+++ b/src/game/simulationWorldContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+import type { World } from "miniplex";
+import type { SimulationEntity } from "../sim/types";
+
+export type SimulationWorldContextValue = {
+  world: World<SimulationEntity>;
+  runSeed: number;
+};
+
+export const SimulationWorldContext = createContext<SimulationWorldContextValue | null>(null);
+
+export function useSimulationWorld(): SimulationWorldContextValue {
+  const ctx = useContext(SimulationWorldContext);
+  if (!ctx) {
+    throw new Error("useSimulationWorld must be used within SimulationWorldProvider");
+  }
+  return ctx;
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -17,6 +17,12 @@ export {
 } from "./world";
 export type { FishKinematicsEntity, FoodPositionEntity } from "./world";
 export {
+  createNewRunSimulationWorld,
+  DEFAULT_SIMULATION_SEED,
+  starterFishEntityForRunSeed,
+} from "./newRunWorld";
+export { STARTER_SPAWN_VOLUME, isWithinStarterSpawnVolume } from "./starterSpawnBounds";
+export {
   MAX_WALL_DELTA_SECONDS_PER_STEP,
   WALL_SECONDS_PER_SIM_DAY,
   advanceClockByWallDelta,

--- a/src/sim/newRunWorld.test.ts
+++ b/src/sim/newRunWorld.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createNewRunSimulationWorld, DEFAULT_SIMULATION_SEED } from "./newRunWorld";
+import { fishWithKinematics } from "./world";
+import { isWithinStarterSpawnVolume } from "./starterSpawnBounds";
+
+describe("createNewRunSimulationWorld", () => {
+  it("spawns exactly one fish for a new run", () => {
+    const world = createNewRunSimulationWorld();
+    expect([...fishWithKinematics(world)]).toHaveLength(1);
+  });
+
+  it("places the starter fish inside the documented starter spawn volume", () => {
+    const world = createNewRunSimulationWorld();
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish).toBeDefined();
+    expect(isWithinStarterSpawnVolume(fish!.position)).toBe(true);
+  });
+
+  it("is deterministic for the default seed (same fish state across runs)", () => {
+    const a = createNewRunSimulationWorld(DEFAULT_SIMULATION_SEED);
+    const b = createNewRunSimulationWorld(DEFAULT_SIMULATION_SEED);
+    const fa = [...fishWithKinematics(a)][0]!;
+    const fb = [...fishWithKinematics(b)][0]!;
+    expect(fa.fish).toEqual(fb.fish);
+    expect(fa.position).toEqual(fb.position);
+    expect(fa.velocity).toEqual(fb.velocity);
+  });
+});

--- a/src/sim/newRunWorld.ts
+++ b/src/sim/newRunWorld.ts
@@ -1,0 +1,35 @@
+import type { World } from "miniplex";
+import type { FishEntity, SimulationEntity } from "./types";
+import { createSimulationWorld, registerFish } from "./world";
+
+/** Default run seed; same seed ⇒ identical starter fish baseline (name, pose, velocity). */
+export const DEFAULT_SIMULATION_SEED = 42;
+
+/**
+ * Canonical starter fish for the default seed (middle of tank, 100g herbivore per `docs/the-game.md`).
+ * `seed` is reserved for future procedural variance; only the default seed is stability-tested for now.
+ */
+export function starterFishEntityForRunSeed(seed: number): FishEntity {
+  void seed;
+  return {
+    fish: {
+      displayName: "Pebble",
+      hungerDays: 0,
+      health: 3,
+      weightGrams: 100,
+      species: { kind: "herbivore" },
+    },
+    position: { x: 0, y: 0.35, z: 0 },
+    velocity: { x: 0, y: 0, z: 0 },
+  };
+}
+
+/**
+ * Creates a Miniplex world for a fresh player run with exactly one starter fish.
+ * Starter placement lies inside `STARTER_SPAWN_VOLUME` (`starterSpawnBounds.ts`).
+ */
+export function createNewRunSimulationWorld(seed: number = DEFAULT_SIMULATION_SEED): World<SimulationEntity> {
+  const world = createSimulationWorld();
+  registerFish(world, starterFishEntityForRunSeed(seed));
+  return world;
+}

--- a/src/sim/starterSpawnBounds.ts
+++ b/src/sim/starterSpawnBounds.ts
@@ -1,0 +1,21 @@
+import type { Vec3 } from "./types";
+
+/**
+ * Conservative inner volume for starter fish placement, aligned with the visible
+ * tank floor mesh in `TankScene` (floor at `TANK_FLOOR_Y` = -0.9, 24×16 plane).
+ * Simulation stays independent of the render module; values are duplicated here
+ * and should be updated if the scene framing changes materially.
+ */
+export const STARTER_SPAWN_VOLUME = {
+  minX: -5.5,
+  maxX: 5.5,
+  minY: -0.82,
+  maxY: 1.35,
+  minZ: -3.5,
+  maxZ: 3.5,
+} as const;
+
+export function isWithinStarterSpawnVolume(p: Vec3): boolean {
+  const { minX, maxX, minY, maxY, minZ, maxZ } = STARTER_SPAWN_VOLUME;
+  return p.x >= minX && p.x <= maxX && p.y >= minY && p.y <= maxY && p.z >= minZ && p.z <= maxZ;
+}

--- a/src/tank/FishMeshesFromWorld.tsx
+++ b/src/tank/FishMeshesFromWorld.tsx
@@ -1,0 +1,29 @@
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import type { Mesh } from "three";
+import { useSimulationWorld } from "../game/simulationWorldContext";
+import { fishWithKinematics } from "../sim/world";
+
+/**
+ * Renders fish from the authoritative ECS world. Reads transforms each frame so
+ * future movement systems stay render-driven without pushing gameplay into R3F.
+ */
+export function FishMeshesFromWorld() {
+  const { world } = useSimulationWorld();
+  const meshRef = useRef<Mesh>(null);
+
+  useFrame(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    const first = [...fishWithKinematics(world)][0];
+    if (!first) return;
+    mesh.position.set(first.position.x, first.position.y, first.position.z);
+  });
+
+  return (
+    <mesh ref={meshRef}>
+      <sphereGeometry args={[0.12, 20, 16]} />
+      <meshStandardMaterial color="#6eb5d9" roughness={0.45} metalness={0.15} />
+    </mesh>
+  );
+}

--- a/src/tank/TankScene.tsx
+++ b/src/tank/TankScene.tsx
@@ -8,6 +8,7 @@ import {
   TANK_FLOOR_Y,
   TANK_SCENE_BACKGROUND,
 } from "./tankCameraConstants";
+import { FishMeshesFromWorld } from "./FishMeshesFromWorld";
 import { SimulationFrameBridge } from "./SimulationFrameBridge";
 
 const sceneBackground = new Color(TANK_SCENE_BACKGROUND);
@@ -38,6 +39,7 @@ export function TankScene({ className, paused = false }: TankSceneProps) {
         }}
       >
         <SimulationFrameBridge />
+        <FishMeshesFromWorld />
         <ambientLight intensity={0.55} />
         <directionalLight position={[4, 6, 3]} intensity={0.85} />
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, TANK_FLOOR_Y, 0]}>


### PR DESCRIPTION
## Linked issue

Closes #4

## Summary

- Adds `createNewRunSimulationWorld` / `starterFishEntityForRunSeed` so a fresh run always registers exactly one valid fish (100g herbivore **Pebble**, center volume, zero velocity) with deterministic baseline for `DEFAULT_SIMULATION_SEED`.
- Documents inner spawn bounds in `starterSpawnBounds.ts` (aligned with visible tank framing; sim stays independent of `src/tank`).
- Wires `SimulationWorldProvider` + `useSimulationWorld` so ECS state is created once per provider mount; `FishMeshesFromWorld` reads `fishWithKinematics` each frame (render derives from sim).

## Verification

```text
pnpm test
```

```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-4-starter-fish
> vitest run
...
 Test Files  10 passed (10)
      Tests  37 passed (37)
```

```text
pnpm lint
```

```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-4-starter-fish
> eslint .
```

```text
pnpm build
```

```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-4-starter-fish
> tsc -b && vite build
...
✓ built in 305ms
```

## Notes

- Depends on #3 (assumed satisfied on `main`).
- `runSeed` on `SimulationWorldProvider` is optional for future non-default runs; only the default seed is contract-tested for identical starter state.