### PR TITLE
#5 Implement fish idle swim movement system

### DIFF
--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -32,3 +32,5 @@ export {
   wallDeltaToSimDays,
 } from "./simulationClock";
 export type { SimulationClockState } from "./simulationClock";
+export { stepFishKinematicsWallDelta } from "./movement/fishKinematics";
+export type { StepFishKinematicsOptions } from "./movement/fishKinematics";

--- a/src/sim/movement/fishKinematics.test.ts
+++ b/src/sim/movement/fishKinematics.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { clampWallDeltaSeconds, wallDeltaToSimDays } from "../simulationClock";
+import { createSimulationWorld, fishWithKinematics, registerFish } from "../world";
+import { isWithinStarterSpawnVolume } from "../starterSpawnBounds";
+import type { SimulationEntity } from "../types";
+import { stepFishKinematicsWallDelta } from "./fishKinematics";
+
+const validFishPayload = {
+  fish: {
+    displayName: "Pebble",
+    hungerDays: 0,
+    health: 3 as const,
+    weightGrams: 100,
+    species: { kind: "herbivore" as const },
+  },
+  position: { x: 0, y: 0.5, z: 0 },
+  velocity: { x: 0, y: 0, z: 0 },
+};
+
+function distanceSq(a: { x: number; y: number; z: number }, b: { x: number; y: number; z: number }) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
+describe("stepFishKinematicsWallDelta", () => {
+  it("advances idle fish position over time while keeping them inside tank bounds", () => {
+    const world = createSimulationWorld();
+    registerFish(world, validFishPayload);
+    const fish = [...fishWithKinematics(world)][0]!;
+    const p0 = { ...fish.position };
+    let simDays = 0;
+    const wallDt = clampWallDeltaSeconds(1 / 60);
+    for (let i = 0; i < 200; i++) {
+      stepFishKinematicsWallDelta(world, { wallDeltaSeconds: wallDt, simTimeDays: simDays });
+      simDays += wallDeltaToSimDays(wallDt);
+      expect(isWithinStarterSpawnVolume(fish.position)).toBe(true);
+    }
+    expect(distanceSq(fish.position, p0)).toBeGreaterThan(1e-4);
+  });
+
+  it("does not idle-wander when movementTargetPosition is set", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, validFishPayload);
+    (fish as SimulationEntity).movementTargetPosition = { x: 2, y: 0.5, z: -1 };
+    const p0 = { ...fish.position };
+    let simDays = 0;
+    const wallDt = clampWallDeltaSeconds(1 / 60);
+    for (let i = 0; i < 120; i++) {
+      stepFishKinematicsWallDelta(world, { wallDeltaSeconds: wallDt, simTimeDays: simDays });
+      simDays += wallDeltaToSimDays(wallDt);
+    }
+    expect(distanceSq(fish.position, p0)).toBeLessThan(1e-6);
+  });
+
+  it("is deterministic for identical step inputs", () => {
+    const run = () => {
+      const world = createSimulationWorld();
+      registerFish(world, validFishPayload);
+      const fish = [...fishWithKinematics(world)][0]!;
+      let simDays = 0;
+      const wallDt = clampWallDeltaSeconds(0.05);
+      for (let i = 0; i < 40; i++) {
+        stepFishKinematicsWallDelta(world, { wallDeltaSeconds: wallDt, simTimeDays: simDays });
+        simDays += wallDeltaToSimDays(wallDt);
+      }
+      return { ...fish.position, ...fish.velocity };
+    };
+    const a = run();
+    const b = run();
+    expect(a).toEqual(b);
+  });
+});

--- a/src/sim/movement/fishKinematics.ts
+++ b/src/sim/movement/fishKinematics.ts
@@ -1,0 +1,96 @@
+import type { World } from "miniplex";
+import { clampWallDeltaSeconds } from "../simulationClock";
+import { STARTER_SPAWN_VOLUME } from "../starterSpawnBounds";
+import type { SimulationEntity, Vec3 } from "../types";
+import { fishWithKinematics, type FishKinematicsEntity } from "../world";
+
+export type StepFishKinematicsOptions = {
+  wallDeltaSeconds: number;
+  /** Simulation time at the start of this kinematics step (game days), for deterministic wander. */
+  simTimeDays: number;
+};
+
+const MAX_IDLE_SPEED = 0.32;
+const VELOCITY_RESPONSIVENESS = 5.5;
+
+function wanderOffsetFromName(displayName: string): number {
+  let h = 0;
+  for (let i = 0; i < displayName.length; i++) {
+    h = (h + displayName.charCodeAt(i) * (i + 17)) % 997;
+  }
+  return h * 0.017;
+}
+
+function hasActiveMovementTarget(entity: FishKinematicsEntity & SimulationEntity): boolean {
+  return entity.movementTargetPosition !== undefined;
+}
+
+function clampPositionResolveVelocity(position: Vec3, velocity: Vec3): void {
+  const { minX, maxX, minY, maxY, minZ, maxZ } = STARTER_SPAWN_VOLUME;
+  if (position.x < minX) {
+    position.x = minX;
+    if (velocity.x < 0) velocity.x = 0;
+  } else if (position.x > maxX) {
+    position.x = maxX;
+    if (velocity.x > 0) velocity.x = 0;
+  }
+  if (position.y < minY) {
+    position.y = minY;
+    if (velocity.y < 0) velocity.y = 0;
+  } else if (position.y > maxY) {
+    position.y = maxY;
+    if (velocity.y > 0) velocity.y = 0;
+  }
+  if (position.z < minZ) {
+    position.z = minZ;
+    if (velocity.z < 0) velocity.z = 0;
+  } else if (position.z > maxZ) {
+    position.z = maxZ;
+    if (velocity.z > 0) velocity.z = 0;
+  }
+}
+
+function desiredIdleVelocity(displayName: string, simTimeDays: number): Vec3 {
+  const offset = wanderOffsetFromName(displayName);
+  const t = simTimeDays * Math.PI * 2 * 1.2 + offset;
+  const ax = Math.sin(t * 1.07);
+  const ay = Math.sin(t * 0.63) * 0.45;
+  const az = Math.cos(t * 0.98);
+  const len = Math.hypot(ax, ay, az) || 1;
+  const s = MAX_IDLE_SPEED / len;
+  return { x: ax * s, y: ay * s, z: az * s };
+}
+
+/**
+ * Movement phase: idle wander for fish with no active movement target.
+ * Mutates ECS `position` / `velocity`; clamped to `STARTER_SPAWN_VOLUME` tank bounds.
+ */
+export function stepFishKinematicsWallDelta(
+  world: World<SimulationEntity>,
+  options: StepFishKinematicsOptions,
+): void {
+  const dt = clampWallDeltaSeconds(options.wallDeltaSeconds);
+  if (dt <= 0) return;
+
+  const { simTimeDays } = options;
+  const blend = 1 - Math.exp(-VELOCITY_RESPONSIVENESS * dt);
+
+  for (const entity of fishWithKinematics(world)) {
+    const e = entity as FishKinematicsEntity & SimulationEntity;
+    if (hasActiveMovementTarget(e)) continue;
+
+    const desired = desiredIdleVelocity(e.fish.displayName, simTimeDays);
+    const v = e.velocity;
+    const p = e.position;
+
+    v.x += (desired.x - v.x) * blend;
+    v.y += (desired.y - v.y) * blend;
+    v.z += (desired.z - v.z) * blend;
+
+    p.x += v.x * dt;
+    p.y += v.y * dt;
+    p.z += v.z * dt;
+
+    clampPositionResolveVelocity(p, v);
+  }
+}

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,4 +47,9 @@ export type SimulationEntity = {
   velocity?: Vec3;
   fish?: FishState;
   food?: FoodState;
+  /**
+   * When set, higher-level targeting owns steering; idle wander is skipped.
+   * Not validated by `assertFishEntityShape` (runtime-only / save-roundtrip optional).
+   */
+  movementTargetPosition?: Vec3;
 };

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -1,15 +1,21 @@
 import { useFrame } from "@react-three/fiber";
 import { useSimulationClock } from "../game/simulationClockContext";
+import { useSimulationWorld } from "../game/simulationWorldContext";
+import { clampWallDeltaSeconds, stepFishKinematicsWallDelta } from "../sim";
 
 /**
- * Maps the R3F frame loop to simulation clock advances. Paused mode stops the
- * canvas frameloop, so this hook does not run while paused.
+ * Maps the R3F frame loop to simulation clock advances and authoritative fish
+ * kinematics. Paused mode stops the canvas frameloop, so this hook does not run while paused.
  */
 export function SimulationFrameBridge() {
-  const { paused, advanceByWallDelta } = useSimulationClock();
+  const { paused, advanceByWallDelta, simDays } = useSimulationClock();
+  const { world } = useSimulationWorld();
+
   useFrame((_, delta) => {
     if (paused) return;
-    advanceByWallDelta(delta);
+    const dt = clampWallDeltaSeconds(delta);
+    stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
+    advanceByWallDelta(dt);
   });
   return null;
 }


### PR DESCRIPTION
## Linked issue

Closes #5

## Summary

- Added `stepFishKinematicsWallDelta` in the sim layer: smooth deterministic idle wander from game-day phase + per-name offset, velocity smoothing, and hard clamp to `STARTER_SPAWN_VOLUME` with wall velocity zeroing.
- Extended `SimulationEntity` with optional `movementTargetPosition`; when set, idle wander is skipped so a future targeting phase can own steering.
- `SimulationFrameBridge` now advances fish kinematics each frame (same wall `dt` as the clock, clamped) before `advanceByWallDelta`, keeping the ECS world authoritative and pause-aligned with the R3F frameloop.

## Verification

```
pnpm test
```

```
> the-aquarium@0.0.0 test
> vitest run
…
 Test Files  11 passed (11)
      Tests  40 passed (40)
```

```
pnpm lint
```

```
> the-aquarium@0.0.0 lint
> eslint .
```

```
pnpm build
```

```
> the-aquarium@0.0.0 build
> tsc -b && vite build
…
✓ built in 249ms
```

## Visual QA

- Ran `pnpm dev`; Vite served **http://localhost:5174/** (5173 was already in use). `curl` returned HTTP 200 for the app shell.
- MCP fetch cannot reach localhost from this environment, so the canvas was not automated. Manual check in a browser on the printed URL: confirm the starter fish drifts smoothly, stays inside the tank volume, pause freezes motion and day counter, resume restores motion, HUD still readable over the canvas.

## Blockers

None.