### PR TITLE
#6 Add hunger timer component to fish entity

### DIFF
--- a/src/sim/hungerTimer.test.ts
+++ b/src/sim/hungerTimer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { createSimulationWorld, fishWithKinematics, registerFish, wallDeltaToSimDays } from "./index";
+import { resetFishHungerAfterSuccessfulMeal, stepHungerTimersWallDelta } from "./hungerTimer";
+
+describe("stepHungerTimersWallDelta", () => {
+  it("advances hungerDays by the same sim-day delta as the simulation clock for that wall step", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "A",
+        hungerDays: 0.5,
+        health: 3,
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const wallDt = 0.1;
+    const expectedDelta = wallDeltaToSimDays(wallDt);
+    stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish!.fish.hungerDays).toBeCloseTo(0.5 + expectedDelta, 10);
+  });
+
+  it("accumulates independently for multiple fish", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "A",
+        hungerDays: 0,
+        health: 3,
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    registerFish(world, {
+      fish: {
+        displayName: "B",
+        hungerDays: 2,
+        health: 2,
+        weightGrams: 200,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0.1, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const wallDt = 0.2;
+    const d = wallDeltaToSimDays(wallDt);
+    stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    const names = new Map([...fishWithKinematics(world)].map((e) => [e.fish.displayName, e.fish.hungerDays]));
+    expect(names.get("A")).toBeCloseTo(0 + d, 10);
+    expect(names.get("B")).toBeCloseTo(2 + d, 10);
+  });
+
+  it("is a no-op for non-positive wall delta", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "A",
+        hungerDays: 1,
+        health: 3,
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    stepHungerTimersWallDelta(world, { wallDeltaSeconds: 0 });
+    stepHungerTimersWallDelta(world, { wallDeltaSeconds: -1 });
+    expect([...fishWithKinematics(world)][0]!.fish.hungerDays).toBe(1);
+  });
+});
+
+describe("resetFishHungerAfterSuccessfulMeal", () => {
+  it("sets hungerDays to zero", () => {
+    const fish = {
+      displayName: "A",
+      hungerDays: 3.7,
+      health: 2 as const,
+      weightGrams: 100,
+      species: { kind: "herbivore" as const },
+    };
+    resetFishHungerAfterSuccessfulMeal(fish);
+    expect(fish.hungerDays).toBe(0);
+  });
+});

--- a/src/sim/hungerTimer.ts
+++ b/src/sim/hungerTimer.ts
@@ -1,0 +1,25 @@
+import type { World } from "miniplex";
+import { wallDeltaToSimDays } from "./simulationClock";
+import type { FishState, SimulationEntity } from "./types";
+import { fishWithKinematics } from "./world";
+
+/**
+ * Vitals-adjacent clock: advances each fish's `hungerDays` by the same in-game day
+ * delta the simulation clock uses for this wall step (`wallDeltaToSimDays`).
+ */
+export function stepHungerTimersWallDelta(
+  world: World<SimulationEntity>,
+  options: { wallDeltaSeconds: number },
+): void {
+  const dSim = wallDeltaToSimDays(options.wallDeltaSeconds);
+  if (dSim <= 0) return;
+
+  for (const entity of fishWithKinematics(world)) {
+    entity.fish.hungerDays += dSim;
+  }
+}
+
+/** Invoked by interaction systems when a fish successfully eats (food or prey). */
+export function resetFishHungerAfterSuccessfulMeal(fish: FishState): void {
+  fish.hungerDays = 0;
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -34,3 +34,10 @@ export {
 export type { SimulationClockState } from "./simulationClock";
 export { stepFishKinematicsWallDelta } from "./movement/fishKinematics";
 export type { StepFishKinematicsOptions } from "./movement/fishKinematics";
+export { resetFishHungerAfterSuccessfulMeal, stepHungerTimersWallDelta } from "./hungerTimer";
+export {
+  SIMULATION_WORLD_SNAPSHOT_VERSION,
+  deserializeSimulationWorldSnapshot,
+  serializeSimulationWorldSnapshot,
+} from "./worldSnapshot";
+export type { SimulationWorldSnapshot } from "./worldSnapshot";

--- a/src/sim/worldSnapshot.test.ts
+++ b/src/sim/worldSnapshot.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertFishEntityShape,
+  createSimulationWorld,
+  fishWithKinematics,
+  foodWithPosition,
+  registerFish,
+  registerFood,
+} from "./index";
+import type { SimulationEntity } from "./types";
+import {
+  deserializeSimulationWorldSnapshot,
+  serializeSimulationWorldSnapshot,
+} from "./worldSnapshot";
+
+describe("simulation world snapshot hooks", () => {
+  it("round-trips fish hungerDays and preserves food entities", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "Hungry",
+        hungerDays: 1.25,
+        health: 3,
+        weightGrams: 150,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0.01, y: 0, z: 0 },
+    });
+    registerFish(world, {
+      fish: {
+        displayName: "Fed",
+        hungerDays: 0,
+        health: 3,
+        weightGrams: 300,
+        species: { kind: "carnivore" },
+      },
+      position: { x: 0.2, y: 0.4, z: -0.1 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    registerFood(world, {
+      food: { spawnedAtSimDays: 0.5 },
+      position: { x: 0.05, y: 0.5, z: 0 },
+    });
+
+    const wire = JSON.stringify(serializeSimulationWorldSnapshot(world));
+    const restored = deserializeSimulationWorldSnapshot(JSON.parse(wire));
+
+    const fishByName = new Map([...fishWithKinematics(restored)].map((e) => [e.fish.displayName, e.fish]));
+    expect(fishByName.get("Hungry")!.hungerDays).toBeCloseTo(1.25, 10);
+    expect(fishByName.get("Fed")!.hungerDays).toBe(0);
+    expect(fishByName.get("Hungry")!.weightGrams).toBe(150);
+    expect(fishByName.get("Fed")!.species).toEqual({ kind: "carnivore" });
+
+    const foods = [...foodWithPosition(restored)];
+    expect(foods).toHaveLength(1);
+    expect(foods[0]!.food.spawnedAtSimDays).toBeCloseTo(0.5, 10);
+    expect(foods[0]!.position.y).toBeCloseTo(0.5, 10);
+  });
+
+  it("round-trips optional movementTargetPosition on fish", () => {
+    const world = createSimulationWorld();
+    const base = assertFishEntityShape({
+      fish: {
+        displayName: "Targeted",
+        hungerDays: 0.1,
+        health: 3,
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const withTarget: SimulationEntity = {
+      ...base,
+      movementTargetPosition: { x: 0.5, y: 0.4, z: 0.2 },
+    };
+    world.add(withTarget);
+
+    const json = JSON.stringify(serializeSimulationWorldSnapshot(world));
+    const restored = deserializeSimulationWorldSnapshot(JSON.parse(json));
+    const [fish] = [...fishWithKinematics(restored)];
+    expect(fish!.movementTargetPosition).toEqual({ x: 0.5, y: 0.4, z: 0.2 });
+  });
+});

--- a/src/sim/worldSnapshot.ts
+++ b/src/sim/worldSnapshot.ts
@@ -1,0 +1,77 @@
+import type { World } from "miniplex";
+import { InvalidEntityShapeError, assertFishEntityShape, assertFoodEntityShape } from "./guards";
+import type { SimulationEntity, Vec3 } from "./types";
+import { createSimulationWorld } from "./world";
+
+export const SIMULATION_WORLD_SNAPSHOT_VERSION = 1 as const;
+
+export type SimulationWorldSnapshot = {
+  version: typeof SIMULATION_WORLD_SNAPSHOT_VERSION;
+  /** Plain JSON-serializable entity records (fish + food archetypes). */
+  entities: unknown[];
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseOptionalMovementTarget(path: string, v: unknown): Vec3 | undefined {
+  if (v === undefined) return undefined;
+  if (!isPlainRecord(v)) {
+    throw new InvalidEntityShapeError([`${path} must be an object with x, y, z numbers`]);
+  }
+  for (const k of ["x", "y", "z"] as const) {
+    const n = v[k];
+    if (typeof n !== "number" || !Number.isFinite(n)) {
+      throw new InvalidEntityShapeError([`${path}.${k} must be a finite number`]);
+    }
+  }
+  return { x: v.x as number, y: v.y as number, z: v.z as number };
+}
+
+function parseSnapshotEntity(raw: unknown, index: number): SimulationEntity {
+  if (!isPlainRecord(raw)) {
+    throw new InvalidEntityShapeError([`entities[${index}] must be a plain object`]);
+  }
+  if (raw.fish !== undefined) {
+    const base = assertFishEntityShape(raw);
+    const out: SimulationEntity = { ...base };
+    if (raw.movementTargetPosition !== undefined) {
+      out.movementTargetPosition = parseOptionalMovementTarget(
+        `entities[${index}].movementTargetPosition`,
+        raw.movementTargetPosition,
+      );
+    }
+    return out;
+  }
+  if (raw.food !== undefined) {
+    return assertFoodEntityShape(raw);
+  }
+  throw new InvalidEntityShapeError([`entities[${index}] must be a fish or food entity`]);
+}
+
+/**
+ * Save hook: returns a JSON-safe snapshot of the world (including each fish's `hungerDays`).
+ * Callers may `JSON.stringify` and persist (e.g. localStorage in a later ticket).
+ */
+export function serializeSimulationWorldSnapshot(world: World<SimulationEntity>): SimulationWorldSnapshot {
+  const entities = world.entities.map((e) => JSON.parse(JSON.stringify(e)) as unknown);
+  return { version: SIMULATION_WORLD_SNAPSHOT_VERSION, entities };
+}
+
+/**
+ * Load hook: rebuilds a `World` from `serializeSimulationWorldSnapshot` output.
+ */
+export function deserializeSimulationWorldSnapshot(data: unknown): World<SimulationEntity> {
+  if (!isPlainRecord(data)) {
+    throw new InvalidEntityShapeError(["snapshot root must be an object"]);
+  }
+  if (data.version !== SIMULATION_WORLD_SNAPSHOT_VERSION) {
+    throw new InvalidEntityShapeError([`unsupported snapshot version: ${String(data.version)}`]);
+  }
+  if (!Array.isArray(data.entities)) {
+    throw new InvalidEntityShapeError(["snapshot.entities must be an array"]);
+  }
+  const entities = data.entities.map((raw, i) => parseSnapshotEntity(raw, i));
+  return createSimulationWorld(entities);
+}

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -1,7 +1,11 @@
 import { useFrame } from "@react-three/fiber";
 import { useSimulationClock } from "../game/simulationClockContext";
 import { useSimulationWorld } from "../game/simulationWorldContext";
-import { clampWallDeltaSeconds, stepFishKinematicsWallDelta } from "../sim";
+import {
+  clampWallDeltaSeconds,
+  stepFishKinematicsWallDelta,
+  stepHungerTimersWallDelta,
+} from "../sim";
 
 /**
  * Maps the R3F frame loop to simulation clock advances and authoritative fish
@@ -15,6 +19,7 @@ export function SimulationFrameBridge() {
     if (paused) return;
     const dt = clampWallDeltaSeconds(delta);
     stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
+    stepHungerTimersWallDelta(world, { wallDeltaSeconds: dt });
     advanceByWallDelta(dt);
   });
   return null;


### PR DESCRIPTION
Closes #6

## Summary
- `stepHungerTimersWallDelta` advances each fish `hungerDays` using the same wall→sim-day mapping as `simulationClock` (single clock).
- `resetFishHungerAfterSuccessfulMeal` for future eat flows.
- `SimulationFrameBridge`: hunger step uses the same clamped wall delta as kinematics + clock; paused canvas means no hunger advance.
- `serializeSimulationWorldSnapshot` / `deserializeSimulationWorldSnapshot` + tests for JSON round-trip (hunger + optional target + food).

## Visual QA
- `pnpm dev` served the app (port may vary if 5173 is busy); HTTP 200 verified.
- **Cursor IDE Browser MCP** was not enabled for this workspace when implemented; manual check: tank + fish + HUD + pause freezes progression.
- Recommend enabling Browser MCP for automated UI passes on future PRs.

## Verification
- `pnpm test` — all passed (13 files, 46 tests at time of push).
- `pnpm lint` — clean.