### PR TITLE
#7 Add hunger threshold transition from healthy to hungry

### DIFF
--- a/src/sim/entities.test.ts
+++ b/src/sim/entities.test.ts
@@ -16,6 +16,7 @@ const validFishPayload = {
     displayName: "Pebble",
     hungerDays: 0,
     health: 3 as const,
+    hungerStage: "healthy" as const,
     weightGrams: 100,
     species: { kind: "herbivore" as const },
   },

--- a/src/sim/fishHungerEventBridge.ts
+++ b/src/sim/fishHungerEventBridge.ts
@@ -1,0 +1,24 @@
+import type { FishBecameHungryEvent } from "./types";
+
+const listeners = new Set<(events: readonly FishBecameHungryEvent[]) => void>();
+
+/** Register a consumer (e.g. toast shell in #17). Returns an unsubscribe function. */
+export function subscribeFishBecameHungryEvents(
+  listener: (events: readonly FishBecameHungryEvent[]) => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Invoked after each hunger timer step with events from that step only.
+ * Multiple transitions in one tick produce multiple events in array order.
+ */
+export function dispatchFishBecameHungryEvents(events: readonly FishBecameHungryEvent[]): void {
+  if (events.length === 0) return;
+  for (const listener of [...listeners]) {
+    listener(events);
+  }
+}

--- a/src/sim/guards.ts
+++ b/src/sim/guards.ts
@@ -1,4 +1,13 @@
-import type { FishEntity, FishSpeciesTag, FishState, FoodEntity, FoodState, Vec3 } from "./types";
+import { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
+import type {
+  FishEntity,
+  FishHungerStage,
+  FishSpeciesTag,
+  FishState,
+  FoodEntity,
+  FoodState,
+  Vec3,
+} from "./types";
 
 export class InvalidEntityShapeError extends Error {
   readonly issues: readonly string[];
@@ -72,14 +81,36 @@ function collectFishState(path: string, v: unknown): { state: FishState } | { er
   if (!species) {
     errors.push(`${path}.species must be { kind: "herbivore" } or { kind: "carnivore" }`);
   }
+  const stageRaw = v.hungerStage;
+  let hungerStage: FishHungerStage | undefined;
+  if (stageRaw === "healthy" || stageRaw === "hungry") {
+    hungerStage = stageRaw;
+  } else if (stageRaw !== undefined) {
+    errors.push(`${path}.hungerStage must be "healthy" or "hungry"`);
+  }
   if (errors.length > 0) {
     return { errors };
   }
+
+  let resolvedHealth = h as 0 | 1 | 2 | 3;
+  if (hungerStage === undefined) {
+    const hungerDays = v.hungerDays as number;
+    if (resolvedHealth === 3 && hungerDays >= FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS) {
+      resolvedHealth = 2;
+      hungerStage = "hungry";
+    } else if (resolvedHealth === 3) {
+      hungerStage = "healthy";
+    } else {
+      hungerStage = "hungry";
+    }
+  }
+
   return {
     state: {
       displayName: v.displayName as string,
       hungerDays: v.hungerDays as number,
-      health: h as 0 | 1 | 2 | 3,
+      health: resolvedHealth,
+      hungerStage,
       weightGrams: v.weightGrams as number,
       species: species as FishSpeciesTag,
     },

--- a/src/sim/hungerConstants.ts
+++ b/src/sim/hungerConstants.ts
@@ -1,0 +1,2 @@
+/** First hunger milestone from `docs/the-game.md` (healthy → hungry, health 3→2). */
+export const FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS = 1.5 as const;

--- a/src/sim/hungerTimer.test.ts
+++ b/src/sim/hungerTimer.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { createSimulationWorld, fishWithKinematics, registerFish, wallDeltaToSimDays } from "./index";
+import { dispatchFishBecameHungryEvents, subscribeFishBecameHungryEvents } from "./fishHungerEventBridge";
+import { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
+import {
+  createSimulationWorld,
+  fishWithKinematics,
+  registerFish,
+  wallDeltaToSimDays,
+} from "./index";
 import { resetFishHungerAfterSuccessfulMeal, stepHungerTimersWallDelta } from "./hungerTimer";
 
 describe("stepHungerTimersWallDelta", () => {
@@ -10,6 +17,7 @@ describe("stepHungerTimersWallDelta", () => {
         displayName: "A",
         hungerDays: 0.5,
         health: 3,
+        hungerStage: "healthy",
         weightGrams: 100,
         species: { kind: "herbivore" },
       },
@@ -18,7 +26,7 @@ describe("stepHungerTimersWallDelta", () => {
     });
     const wallDt = 0.1;
     const expectedDelta = wallDeltaToSimDays(wallDt);
-    stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt })).toEqual([]);
     const [fish] = [...fishWithKinematics(world)];
     expect(fish!.fish.hungerDays).toBeCloseTo(0.5 + expectedDelta, 10);
   });
@@ -30,6 +38,7 @@ describe("stepHungerTimersWallDelta", () => {
         displayName: "A",
         hungerDays: 0,
         health: 3,
+        hungerStage: "healthy",
         weightGrams: 100,
         species: { kind: "herbivore" },
       },
@@ -41,6 +50,7 @@ describe("stepHungerTimersWallDelta", () => {
         displayName: "B",
         hungerDays: 2,
         health: 2,
+        hungerStage: "hungry",
         weightGrams: 200,
         species: { kind: "herbivore" },
       },
@@ -49,7 +59,7 @@ describe("stepHungerTimersWallDelta", () => {
     });
     const wallDt = 0.2;
     const d = wallDeltaToSimDays(wallDt);
-    stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt })).toEqual([]);
     const names = new Map([...fishWithKinematics(world)].map((e) => [e.fish.displayName, e.fish.hungerDays]));
     expect(names.get("A")).toBeCloseTo(0 + d, 10);
     expect(names.get("B")).toBeCloseTo(2 + d, 10);
@@ -62,28 +72,109 @@ describe("stepHungerTimersWallDelta", () => {
         displayName: "A",
         hungerDays: 1,
         health: 3,
+        hungerStage: "healthy",
         weightGrams: 100,
         species: { kind: "herbivore" },
       },
       position: { x: 0, y: 0.35, z: 0 },
       velocity: { x: 0, y: 0, z: 0 },
     });
-    stepHungerTimersWallDelta(world, { wallDeltaSeconds: 0 });
-    stepHungerTimersWallDelta(world, { wallDeltaSeconds: -1 });
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: 0 })).toEqual([]);
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: -1 })).toEqual([]);
     expect([...fishWithKinematics(world)][0]!.fish.hungerDays).toBe(1);
+  });
+
+  it("at the first threshold applies health 3→2, hungerStage hungry, exactly once per crossing", () => {
+    const world = createSimulationWorld();
+    const startBelow = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 0.01;
+    registerFish(world, {
+      fish: {
+        displayName: "Crosser",
+        hungerDays: startBelow,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    /** 0.065 wall seconds ⇒ 0.01 sim days at default speed (`WALL_SECONDS_PER_SIM_DAY`). */
+    const wallDt = 0.065;
+    const ev = stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish!.fish.health).toBe(2);
+    expect(fish!.fish.hungerStage).toBe("hungry");
+    expect(ev).toEqual([{ kind: "fish_became_hungry", displayName: "Crosser" }]);
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt })).toEqual([]);
+    expect(fish!.fish.health).toBe(2);
+    expect(fish!.fish.hungerStage).toBe("hungry");
+  });
+
+  it("delivers one event per crossing to a subscribed test double", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "Toasty",
+        hungerDays: FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 1e-6,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const batches: { kind: string; displayName: string }[][] = [];
+    const unsub = subscribeFishBecameHungryEvents((events) => {
+      batches.push([...events]);
+    });
+    try {
+      const wallDt = 0.001;
+      dispatchFishBecameHungryEvents(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt }));
+      dispatchFishBecameHungryEvents(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt }));
+      expect(batches).toHaveLength(1);
+      expect(batches[0]).toEqual([{ kind: "fish_became_hungry", displayName: "Toasty" }]);
+    } finally {
+      unsub();
+    }
+  });
+
+  it("emits one event per fish when two cross the threshold in the same step", () => {
+    const world = createSimulationWorld();
+    const edge = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 0.01;
+    for (const name of ["One", "Two"] as const) {
+      registerFish(world, {
+        fish: {
+          displayName: name,
+          hungerDays: edge,
+          health: 3,
+          hungerStage: "healthy",
+          weightGrams: 100,
+          species: { kind: "herbivore" },
+        },
+        position: { x: name === "One" ? 0 : 0.1, y: 0.35, z: 0 },
+        velocity: { x: 0, y: 0, z: 0 },
+      });
+    }
+    const ev = stepHungerTimersWallDelta(world, { wallDeltaSeconds: 0.065 });
+    expect(ev).toHaveLength(2);
+    expect(ev.map((e) => e.displayName).sort()).toEqual(["One", "Two"]);
   });
 });
 
 describe("resetFishHungerAfterSuccessfulMeal", () => {
-  it("sets hungerDays to zero", () => {
+  it("sets hungerDays to zero and hungerStage to healthy", () => {
     const fish = {
       displayName: "A",
       hungerDays: 3.7,
       health: 2 as const,
+      hungerStage: "hungry" as const,
       weightGrams: 100,
       species: { kind: "herbivore" as const },
     };
     resetFishHungerAfterSuccessfulMeal(fish);
     expect(fish.hungerDays).toBe(0);
+    expect(fish.hungerStage).toBe("healthy");
   });
 });

--- a/src/sim/hungerTimer.ts
+++ b/src/sim/hungerTimer.ts
@@ -1,25 +1,49 @@
 import type { World } from "miniplex";
+import { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
 import { wallDeltaToSimDays } from "./simulationClock";
-import type { FishState, SimulationEntity } from "./types";
+import type { FishBecameHungryEvent, FishState, SimulationEntity } from "./types";
 import { fishWithKinematics } from "./world";
 
 /**
  * Vitals-adjacent clock: advances each fish's `hungerDays` by the same in-game day
  * delta the simulation clock uses for this wall step (`wallDeltaToSimDays`).
+ *
+ * When a fish first crosses {@link FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS} while still
+ * `healthy`, health drops 3→2, `hungerStage` becomes `"hungry"`, and one event is returned.
  */
 export function stepHungerTimersWallDelta(
   world: World<SimulationEntity>,
   options: { wallDeltaSeconds: number },
-): void {
+): readonly FishBecameHungryEvent[] {
   const dSim = wallDeltaToSimDays(options.wallDeltaSeconds);
-  if (dSim <= 0) return;
+  if (dSim <= 0) return [];
+
+  const events: FishBecameHungryEvent[] = [];
+  const threshold = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS;
 
   for (const entity of fishWithKinematics(world)) {
-    entity.fish.hungerDays += dSim;
+    const fish = entity.fish;
+    const before = fish.hungerDays;
+    fish.hungerDays += dSim;
+    const after = fish.hungerDays;
+
+    if (
+      before < threshold &&
+      after >= threshold &&
+      fish.hungerStage === "healthy" &&
+      fish.health === 3
+    ) {
+      fish.health = 2;
+      fish.hungerStage = "hungry";
+      events.push({ kind: "fish_became_hungry", displayName: fish.displayName });
+    }
   }
+
+  return events;
 }
 
 /** Invoked by interaction systems when a fish successfully eats (food or prey). */
 export function resetFishHungerAfterSuccessfulMeal(fish: FishState): void {
   fish.hungerDays = 0;
+  fish.hungerStage = "healthy";
 }

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -1,5 +1,7 @@
 export type {
+  FishBecameHungryEvent,
   FishEntity,
+  FishHungerStage,
   FishSpeciesTag,
   FishState,
   FoodEntity,
@@ -34,9 +36,12 @@ export {
 export type { SimulationClockState } from "./simulationClock";
 export { stepFishKinematicsWallDelta } from "./movement/fishKinematics";
 export type { StepFishKinematicsOptions } from "./movement/fishKinematics";
+export { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
+export { dispatchFishBecameHungryEvents, subscribeFishBecameHungryEvents } from "./fishHungerEventBridge";
 export { resetFishHungerAfterSuccessfulMeal, stepHungerTimersWallDelta } from "./hungerTimer";
 export {
   SIMULATION_WORLD_SNAPSHOT_VERSION,
+  SIMULATION_WORLD_SNAPSHOT_VERSION_V1,
   deserializeSimulationWorldSnapshot,
   serializeSimulationWorldSnapshot,
 } from "./worldSnapshot";

--- a/src/sim/movement/fishKinematics.test.ts
+++ b/src/sim/movement/fishKinematics.test.ts
@@ -10,6 +10,7 @@ const validFishPayload = {
     displayName: "Pebble",
     hungerDays: 0,
     health: 3 as const,
+    hungerStage: "healthy" as const,
     weightGrams: 100,
     species: { kind: "herbivore" as const },
   },

--- a/src/sim/newRunWorld.ts
+++ b/src/sim/newRunWorld.ts
@@ -16,6 +16,7 @@ export function starterFishEntityForRunSeed(seed: number): FishEntity {
       displayName: "Pebble",
       hungerDays: 0,
       health: 3,
+      hungerStage: "healthy",
       weightGrams: 100,
       species: { kind: "herbivore" },
     },

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3,6 +3,15 @@ export type Vec3 = { x: number; y: number; z: number };
 
 export type FishSpeciesTag = { kind: "herbivore" } | { kind: "carnivore" };
 
+/** Hunger vitals label; first milestone only (`#7`) — later milestones extend this union. */
+export type FishHungerStage = "healthy" | "hungry";
+
+/** Emitted once when a fish crosses the first hunger threshold (healthy → hungry). */
+export type FishBecameHungryEvent = {
+  kind: "fish_became_hungry";
+  displayName: string;
+};
+
 /**
  * Fish-only simulation fields (movement uses shared `position` / `velocity`).
  * Hunger and health align with `docs/the-game.md` (health 0–3, per-fish hunger clock).
@@ -12,6 +21,8 @@ export type FishState = {
   /** Days since last meal; 0 means just ate. */
   hungerDays: number;
   health: 0 | 1 | 2 | 3;
+  /** Player-facing hunger band; updated on threshold crossings (see `docs/the-game.md`). */
+  hungerStage: FishHungerStage;
   weightGrams: number;
   species: FishSpeciesTag;
 };

--- a/src/sim/worldSnapshot.test.ts
+++ b/src/sim/worldSnapshot.test.ts
@@ -9,6 +9,8 @@ import {
 } from "./index";
 import type { SimulationEntity } from "./types";
 import {
+  SIMULATION_WORLD_SNAPSHOT_VERSION,
+  SIMULATION_WORLD_SNAPSHOT_VERSION_V1,
   deserializeSimulationWorldSnapshot,
   serializeSimulationWorldSnapshot,
 } from "./worldSnapshot";
@@ -21,6 +23,7 @@ describe("simulation world snapshot hooks", () => {
         displayName: "Hungry",
         hungerDays: 1.25,
         health: 3,
+        hungerStage: "healthy",
         weightGrams: 150,
         species: { kind: "herbivore" },
       },
@@ -32,6 +35,7 @@ describe("simulation world snapshot hooks", () => {
         displayName: "Fed",
         hungerDays: 0,
         health: 3,
+        hungerStage: "healthy",
         weightGrams: 300,
         species: { kind: "carnivore" },
       },
@@ -48,7 +52,9 @@ describe("simulation world snapshot hooks", () => {
 
     const fishByName = new Map([...fishWithKinematics(restored)].map((e) => [e.fish.displayName, e.fish]));
     expect(fishByName.get("Hungry")!.hungerDays).toBeCloseTo(1.25, 10);
+    expect(fishByName.get("Hungry")!.hungerStage).toBe("healthy");
     expect(fishByName.get("Fed")!.hungerDays).toBe(0);
+    expect(fishByName.get("Fed")!.hungerStage).toBe("healthy");
     expect(fishByName.get("Hungry")!.weightGrams).toBe(150);
     expect(fishByName.get("Fed")!.species).toEqual({ kind: "carnivore" });
 
@@ -58,6 +64,48 @@ describe("simulation world snapshot hooks", () => {
     expect(foods[0]!.position.y).toBeCloseTo(0.5, 10);
   });
 
+  it("serializes snapshot format version 2", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "V2",
+        hungerDays: 0,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const snap = serializeSimulationWorldSnapshot(world);
+    expect(snap.version).toBe(SIMULATION_WORLD_SNAPSHOT_VERSION);
+  });
+
+  it("deserializes v1 snapshots without hungerStage using legacy inference", () => {
+    const legacy = {
+      version: SIMULATION_WORLD_SNAPSHOT_VERSION_V1,
+      entities: [
+        {
+          fish: {
+            displayName: "Legacy",
+            hungerDays: 2,
+            health: 3,
+            weightGrams: 100,
+            species: { kind: "herbivore" },
+          },
+          position: { x: 0, y: 0.35, z: 0 },
+          velocity: { x: 0, y: 0, z: 0 },
+        },
+      ],
+    };
+    const world = deserializeSimulationWorldSnapshot(legacy);
+    const [f] = [...fishWithKinematics(world)];
+    expect(f!.fish.health).toBe(2);
+    expect(f!.fish.hungerStage).toBe("hungry");
+    expect(f!.fish.hungerDays).toBe(2);
+  });
+
   it("round-trips optional movementTargetPosition on fish", () => {
     const world = createSimulationWorld();
     const base = assertFishEntityShape({
@@ -65,6 +113,7 @@ describe("simulation world snapshot hooks", () => {
         displayName: "Targeted",
         hungerDays: 0.1,
         health: 3,
+        hungerStage: "healthy",
         weightGrams: 100,
         species: { kind: "herbivore" },
       },

--- a/src/sim/worldSnapshot.ts
+++ b/src/sim/worldSnapshot.ts
@@ -3,10 +3,13 @@ import { InvalidEntityShapeError, assertFishEntityShape, assertFoodEntityShape }
 import type { SimulationEntity, Vec3 } from "./types";
 import { createSimulationWorld } from "./world";
 
-export const SIMULATION_WORLD_SNAPSHOT_VERSION = 1 as const;
+export const SIMULATION_WORLD_SNAPSHOT_VERSION = 2 as const;
+
+/** Legacy snapshots before `FishState.hungerStage` (`#7`). */
+export const SIMULATION_WORLD_SNAPSHOT_VERSION_V1 = 1 as const;
 
 export type SimulationWorldSnapshot = {
-  version: typeof SIMULATION_WORLD_SNAPSHOT_VERSION;
+  version: typeof SIMULATION_WORLD_SNAPSHOT_VERSION | typeof SIMULATION_WORLD_SNAPSHOT_VERSION_V1;
   /** Plain JSON-serializable entity records (fish + food archetypes). */
   entities: unknown[];
 };
@@ -66,7 +69,7 @@ export function deserializeSimulationWorldSnapshot(data: unknown): World<Simulat
   if (!isPlainRecord(data)) {
     throw new InvalidEntityShapeError(["snapshot root must be an object"]);
   }
-  if (data.version !== SIMULATION_WORLD_SNAPSHOT_VERSION) {
+  if (data.version !== SIMULATION_WORLD_SNAPSHOT_VERSION && data.version !== SIMULATION_WORLD_SNAPSHOT_VERSION_V1) {
     throw new InvalidEntityShapeError([`unsupported snapshot version: ${String(data.version)}`]);
   }
   if (!Array.isArray(data.entities)) {

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -3,6 +3,7 @@ import { useSimulationClock } from "../game/simulationClockContext";
 import { useSimulationWorld } from "../game/simulationWorldContext";
 import {
   clampWallDeltaSeconds,
+  dispatchFishBecameHungryEvents,
   stepFishKinematicsWallDelta,
   stepHungerTimersWallDelta,
 } from "../sim";
@@ -19,7 +20,8 @@ export function SimulationFrameBridge() {
     if (paused) return;
     const dt = clampWallDeltaSeconds(delta);
     stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
-    stepHungerTimersWallDelta(world, { wallDeltaSeconds: dt });
+    const hungerEvents = stepHungerTimersWallDelta(world, { wallDeltaSeconds: dt });
+    dispatchFishBecameHungryEvents(hungerEvents);
     advanceByWallDelta(dt);
   });
   return null;


### PR DESCRIPTION
## Linked issue

Closes #7 (depends on #6 — merged on `main`).

## Summary

- First hunger milestone at **1.5 sim days** (`FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS`): `hungerStage` becomes `"hungry"`, **health 3→2**, once per threshold crossing.
- `stepHungerTimersWallDelta` returns a **typed event list** (`fish_became_hungry` per crossing); `SimulationFrameBridge` forwards them through **`subscribeFishBecameHungryEvents` / `dispatchFishBecameHungryEvents`** for a decoupled toast hook (#17).
- `FishState` gains **`hungerStage`**; **`resetFishHungerAfterSuccessfulMeal`** resets it to `"healthy"`.
- **Snapshot format v2**; **v1** snapshots still load (fish without `hungerStage` infer stage + clamp health when clock already past the first threshold).

## Verification

\`\`\`text
$ pnpm test
 Test Files  13 passed (13)
      Tests  51 passed (51)

$ pnpm lint
> eslint .

$ pnpm build
✓ built in 244ms
\`\`\`

## Visual QA

- `pnpm dev` — Vite served **http://localhost:5174/** (5173 was busy); **HTTP 200** on load.
- **cursor-ide-browser** MCP tools were **not** available in this session.
- **Manual checks** (recommended): load the tank, leave unpaused ~10s real time (~1.5 sim days per `docs/the-game.md`); confirm sim stays stable (no console errors). Optional: temporarily `subscribeFishBecameHungryEvents` in dev to log transitions.

## Follow-ups

- #8 / further thresholds: extend `FishHungerStage` and hunger step.
- #17: wire toast shell to `subscribeFishBecameHungryEvents`.