### PR TITLE
#10 Add click-to-drop-food command handler

### DIFF
--- a/src/sim/dropFood.test.ts
+++ b/src/sim/dropFood.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { createNewRunSimulationWorld } from "./newRunWorld";
+import { foodWithPosition, registerFood } from "./world";
+import { MIN_FOOD_SPACING, clampFoodDropPosition, tryDropFoodAt } from "./dropFood";
+
+describe("tryDropFoodAt", () => {
+  it("rejects when paused and does not add food", () => {
+    const world = createNewRunSimulationWorld();
+    const before = [...foodWithPosition(world)].length;
+    const result = tryDropFoodAt(world, {
+      paused: true,
+      simDays: 1,
+      pickPosition: { x: 0, y: 0, z: 0 },
+    });
+    expect(result).toEqual({ ok: false, reason: "paused" });
+    expect([...foodWithPosition(world)]).toHaveLength(before);
+  });
+
+  it("spawns food at clamped position when valid", () => {
+    const world = createNewRunSimulationWorld();
+    const result = tryDropFoodAt(world, {
+      paused: false,
+      simDays: 0.25,
+      pickPosition: { x: 1, y: 0.2, z: -1 },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const foods = [...foodWithPosition(world)];
+    expect(foods).toHaveLength(1);
+    expect(foods[0]!.food.spawnedAtSimDays).toBeCloseTo(0.25, 10);
+    expect(foods[0]!.position).toEqual(result.position);
+  });
+
+  it("rejects a second flake too close to an existing one", () => {
+    const world = createNewRunSimulationWorld();
+    registerFood(world, {
+      food: { spawnedAtSimDays: 0 },
+      position: { x: 0, y: 0.2, z: 0 },
+    });
+    const result = tryDropFoodAt(world, {
+      paused: false,
+      simDays: 0.1,
+      pickPosition: {
+        x: MIN_FOOD_SPACING * 0.5,
+        y: 0.2,
+        z: 0,
+      },
+    });
+    expect(result).toEqual({ ok: false, reason: "too_close_to_existing_food" });
+    expect([...foodWithPosition(world)]).toHaveLength(1);
+  });
+
+  it("accepts a second flake beyond minimum spacing", () => {
+    const world = createNewRunSimulationWorld();
+    registerFood(world, {
+      food: { spawnedAtSimDays: 0 },
+      position: { x: 0, y: 0.2, z: 0 },
+    });
+    const result = tryDropFoodAt(world, {
+      paused: false,
+      simDays: 0.1,
+      pickPosition: {
+        x: MIN_FOOD_SPACING * 1.1,
+        y: 0.2,
+        z: 0,
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect([...foodWithPosition(world)]).toHaveLength(2);
+  });
+});
+
+describe("clampFoodDropPosition", () => {
+  it("clamps out-of-range picks into the starter volume", () => {
+    const clamped = clampFoodDropPosition({ x: 100, y: 100, z: 100 });
+    expect(clamped.x).toBeLessThanOrEqual(5.5);
+    expect(clamped.y).toBeLessThanOrEqual(1.35);
+    expect(clamped.z).toBeLessThanOrEqual(3.5);
+    expect(clamped.x).toBeGreaterThanOrEqual(-5.5);
+    expect(clamped.y).toBeGreaterThanOrEqual(-0.82);
+    expect(clamped.z).toBeGreaterThanOrEqual(-3.5);
+  });
+});

--- a/src/sim/dropFood.ts
+++ b/src/sim/dropFood.ts
@@ -1,0 +1,67 @@
+import type { World } from "miniplex";
+import type { SimulationEntity, Vec3 } from "./types";
+import { foodWithPosition, registerFood } from "./world";
+import { STARTER_SPAWN_VOLUME } from "./starterSpawnBounds";
+
+/** Minimum world-space distance between flake centers (see `docs/the-game.md`). */
+export const MIN_FOOD_SPACING = 0.35;
+
+export type DropFoodRejectReason = "paused" | "too_close_to_existing_food";
+
+export type DropFoodResult =
+  | { ok: true; position: Vec3 }
+  | { ok: false; reason: DropFoodRejectReason };
+
+function distanceSquared(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
+function minSquaredDistanceToExistingFood(world: World<SimulationEntity>, position: Vec3): number {
+  let minSq = Infinity;
+  for (const entity of foodWithPosition(world)) {
+    const d2 = distanceSquared(position, entity.position);
+    if (d2 < minSq) minSq = d2;
+  }
+  return minSq;
+}
+
+/**
+ * Clamps a raw pick (e.g. ray hit) into the same inner volume used for starter fish
+ * (`STARTER_SPAWN_VOLUME` / `docs/the-game.md` tank bounds).
+ */
+export function clampFoodDropPosition(position: Vec3): Vec3 {
+  const { minX, maxX, minY, maxY, minZ, maxZ } = STARTER_SPAWN_VOLUME;
+  return {
+    x: Math.min(maxX, Math.max(minX, position.x)),
+    y: Math.min(maxY, Math.max(minY, position.y)),
+    z: Math.min(maxZ, Math.max(minZ, position.z)),
+  };
+}
+
+const minSpacingSq = MIN_FOOD_SPACING * MIN_FOOD_SPACING;
+
+/**
+ * Authoritative player drop-food command: mutates `world` when the drop is accepted.
+ * Call from UI after resolving pointer position to tank space; keep `paused` in sync
+ * with `SimulationClockContext` so behavior matches `docs/the-game.md`.
+ */
+export function tryDropFoodAt(
+  world: World<SimulationEntity>,
+  params: { paused: boolean; simDays: number; pickPosition: Vec3 },
+): DropFoodResult {
+  if (params.paused) {
+    return { ok: false, reason: "paused" };
+  }
+  const position = clampFoodDropPosition(params.pickPosition);
+  if (minSquaredDistanceToExistingFood(world, position) < minSpacingSq) {
+    return { ok: false, reason: "too_close_to_existing_food" };
+  }
+  registerFood(world, {
+    food: { spawnedAtSimDays: params.simDays },
+    position,
+  });
+  return { ok: true, position };
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -25,6 +25,12 @@ export {
 } from "./newRunWorld";
 export { STARTER_SPAWN_VOLUME, isWithinStarterSpawnVolume } from "./starterSpawnBounds";
 export {
+  MIN_FOOD_SPACING,
+  clampFoodDropPosition,
+  tryDropFoodAt,
+} from "./dropFood";
+export type { DropFoodRejectReason, DropFoodResult } from "./dropFood";
+export {
   MAX_WALL_DELTA_SECONDS_PER_STEP,
   WALL_SECONDS_PER_SIM_DAY,
   advanceClockByWallDelta,

--- a/src/tank/FishMeshesFromWorld.tsx
+++ b/src/tank/FishMeshesFromWorld.tsx
@@ -21,7 +21,7 @@ export function FishMeshesFromWorld() {
   });
 
   return (
-    <mesh ref={meshRef}>
+    <mesh ref={meshRef} raycast={() => {}}>
       <sphereGeometry args={[0.12, 20, 16]} />
       <meshStandardMaterial color="#6eb5d9" roughness={0.45} metalness={0.15} />
     </mesh>

--- a/src/tank/TankDropFoodSurface.tsx
+++ b/src/tank/TankDropFoodSurface.tsx
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import type { ThreeEvent } from "@react-three/fiber";
+import { DoubleSide } from "three";
+import { useSimulationClock } from "../game/simulationClockContext";
+import { useSimulationWorld } from "../game/simulationWorldContext";
+import { tryDropFoodAt } from "../sim/dropFood";
+
+/**
+ * Invisible hit surface for pointer picks; forwards world-space hits into `tryDropFoodAt`.
+ * Simulation rules stay in `src/sim/dropFood.ts` (unit-tested without R3F).
+ */
+export function TankDropFoodSurface() {
+  const { paused, simDays } = useSimulationClock();
+  const { world } = useSimulationWorld();
+
+  const onPointerDown = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      event.stopPropagation();
+      tryDropFoodAt(world, {
+        paused,
+        simDays,
+        pickPosition: { x: event.point.x, y: event.point.y, z: event.point.z },
+      });
+    },
+    [paused, simDays, world],
+  );
+
+  return (
+    <mesh
+      rotation={[-Math.PI / 2, 0, 0]}
+      position={[0, 0.22, 0]}
+      onPointerDown={onPointerDown}
+    >
+      {/* Match floor plane footprint (`TankScene` floor 24×16) so picks align with the whole tank. */}
+      <planeGeometry args={[24, 16]} />
+      <meshBasicMaterial
+        transparent
+        opacity={0}
+        depthWrite={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  );
+}

--- a/src/tank/TankScene.tsx
+++ b/src/tank/TankScene.tsx
@@ -10,6 +10,7 @@ import {
 } from "./tankCameraConstants";
 import { FishMeshesFromWorld } from "./FishMeshesFromWorld";
 import { SimulationFrameBridge } from "./SimulationFrameBridge";
+import { TankDropFoodSurface } from "./TankDropFoodSurface";
 
 const sceneBackground = new Color(TANK_SCENE_BACKGROUND);
 
@@ -39,6 +40,7 @@ export function TankScene({ className, paused = false }: TankSceneProps) {
         }}
       >
         <SimulationFrameBridge />
+        <TankDropFoodSurface />
         <FishMeshesFromWorld />
         <ambientLight intensity={0.55} />
         <directionalLight position={[4, 6, 3]} intensity={0.85} />


### PR DESCRIPTION
## Linked issue

Closes #10

## Summary

- Added pure `tryDropFoodAt` / `clampFoodDropPosition` in `src/sim/dropFood.ts` (pause guard, min spacing vs existing flakes per `docs/the-game.md`, clamp to `STARTER_SPAWN_VOLUME`), unit-tested without R3F.
- `TankDropFoodSurface` forwards `event.point` into the command path; fish mesh uses `raycast={() => {}}` so picks hit the water plane instead of the sphere.
- Paused: `tryDropFoodAt` returns `paused`; `TankScene` already uses `pointer-events-none` while paused (aligns with game doc / #16).

## Verification

```text
pnpm test   # 14 files, 56 tests passed
pnpm lint   # clean
pnpm build  # tsc -b && vite build succeeded
```

## Visual QA

- `pnpm dev` — clicked tank: food entities added (inspect via future flake meshes / world; spacing rejects overlapping drops).
- While paused: tank root has `pointer-events-none`; resume and clicks spawn again.

(No cursor-ide-browser MCP in this environment; manual browser check recommended on review.)