### PR TITLE
#8 Add hunger threshold transition from hungry to starving

### DIFF
--- a/src/sim/fishHungerEventBridge.ts
+++ b/src/sim/fishHungerEventBridge.ts
@@ -1,10 +1,10 @@
-import type { FishBecameHungryEvent } from "./types";
+import type { FishHungerMilestoneEvent } from "./types";
 
-const listeners = new Set<(events: readonly FishBecameHungryEvent[]) => void>();
+const listeners = new Set<(events: readonly FishHungerMilestoneEvent[]) => void>();
 
 /** Register a consumer (e.g. toast shell in #17). Returns an unsubscribe function. */
-export function subscribeFishBecameHungryEvents(
-  listener: (events: readonly FishBecameHungryEvent[]) => void,
+export function subscribeFishHungerMilestoneEvents(
+  listener: (events: readonly FishHungerMilestoneEvent[]) => void,
 ): () => void {
   listeners.add(listener);
   return () => {
@@ -16,7 +16,7 @@ export function subscribeFishBecameHungryEvents(
  * Invoked after each hunger timer step with events from that step only.
  * Multiple transitions in one tick produce multiple events in array order.
  */
-export function dispatchFishBecameHungryEvents(events: readonly FishBecameHungryEvent[]): void {
+export function dispatchFishHungerMilestoneEvents(events: readonly FishHungerMilestoneEvent[]): void {
   if (events.length === 0) return;
   for (const listener of [...listeners]) {
     listener(events);

--- a/src/sim/guards.ts
+++ b/src/sim/guards.ts
@@ -1,4 +1,7 @@
-import { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
+import {
+  FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+} from "./hungerConstants";
 import type {
   FishEntity,
   FishHungerStage,
@@ -83,10 +86,10 @@ function collectFishState(path: string, v: unknown): { state: FishState } | { er
   }
   const stageRaw = v.hungerStage;
   let hungerStage: FishHungerStage | undefined;
-  if (stageRaw === "healthy" || stageRaw === "hungry") {
+  if (stageRaw === "healthy" || stageRaw === "hungry" || stageRaw === "starving") {
     hungerStage = stageRaw;
   } else if (stageRaw !== undefined) {
-    errors.push(`${path}.hungerStage must be "healthy" or "hungry"`);
+    errors.push(`${path}.hungerStage must be "healthy", "hungry", or "starving"`);
   }
   if (errors.length > 0) {
     return { errors };
@@ -98,10 +101,15 @@ function collectFishState(path: string, v: unknown): { state: FishState } | { er
     if (resolvedHealth === 3 && hungerDays >= FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS) {
       resolvedHealth = 2;
       hungerStage = "hungry";
+    } else if (resolvedHealth === 2 && hungerDays >= SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS) {
+      resolvedHealth = 1;
+      hungerStage = "starving";
     } else if (resolvedHealth === 3) {
       hungerStage = "healthy";
-    } else {
+    } else if (resolvedHealth === 2) {
       hungerStage = "hungry";
+    } else {
+      hungerStage = "starving";
     }
   }
 

--- a/src/sim/hungerConstants.ts
+++ b/src/sim/hungerConstants.ts
@@ -1,2 +1,5 @@
 /** First hunger milestone from `docs/the-game.md` (healthy → hungry, health 3→2). */
 export const FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS = 1.5 as const;
+
+/** Second hunger milestone from `docs/the-game.md` (hungry → starving, health 2→1). */
+export const SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS = 3 as const;

--- a/src/sim/hungerTimer.test.ts
+++ b/src/sim/hungerTimer.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { dispatchFishBecameHungryEvents, subscribeFishBecameHungryEvents } from "./fishHungerEventBridge";
-import { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
+import {
+  dispatchFishHungerMilestoneEvents,
+  subscribeFishHungerMilestoneEvents,
+} from "./fishHungerEventBridge";
+import {
+  FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+} from "./hungerConstants";
 import {
   createSimulationWorld,
   fishWithKinematics,
   registerFish,
   wallDeltaToSimDays,
 } from "./index";
-import { resetFishHungerAfterSuccessfulMeal, stepHungerTimersWallDelta } from "./hungerTimer";
+import {
+  resetFishHungerAfterSuccessfulMeal,
+  stepHungerTimersSimDayDelta,
+  stepHungerTimersWallDelta,
+} from "./hungerTimer";
 
 describe("stepHungerTimersWallDelta", () => {
   it("advances hungerDays by the same sim-day delta as the simulation clock for that wall step", () => {
@@ -111,6 +121,30 @@ describe("stepHungerTimersWallDelta", () => {
     expect(fish!.fish.hungerStage).toBe("hungry");
   });
 
+  it("at the second threshold applies health 2→1, hungerStage starving, exactly once per crossing", () => {
+    const world = createSimulationWorld();
+    const startBelow = SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 0.01;
+    registerFish(world, {
+      fish: {
+        displayName: "Starver",
+        hungerDays: startBelow,
+        health: 2,
+        hungerStage: "hungry",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const wallDt = 0.065;
+    const ev = stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish!.fish.health).toBe(1);
+    expect(fish!.fish.hungerStage).toBe("starving");
+    expect(ev).toEqual([{ kind: "fish_became_starving", displayName: "Starver" }]);
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt })).toEqual([]);
+  });
+
   it("delivers one event per crossing to a subscribed test double", () => {
     const world = createSimulationWorld();
     registerFish(world, {
@@ -126,13 +160,13 @@ describe("stepHungerTimersWallDelta", () => {
       velocity: { x: 0, y: 0, z: 0 },
     });
     const batches: { kind: string; displayName: string }[][] = [];
-    const unsub = subscribeFishBecameHungryEvents((events) => {
+    const unsub = subscribeFishHungerMilestoneEvents((events) => {
       batches.push([...events]);
     });
     try {
       const wallDt = 0.001;
-      dispatchFishBecameHungryEvents(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt }));
-      dispatchFishBecameHungryEvents(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt }));
+      dispatchFishHungerMilestoneEvents(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt }));
+      dispatchFishHungerMilestoneEvents(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt }));
       expect(batches).toHaveLength(1);
       expect(batches[0]).toEqual([{ kind: "fish_became_hungry", displayName: "Toasty" }]);
     } finally {
@@ -140,7 +174,7 @@ describe("stepHungerTimersWallDelta", () => {
     }
   });
 
-  it("emits one event per fish when two cross the threshold in the same step", () => {
+  it("emits one event per fish when two cross the first threshold in the same step", () => {
     const world = createSimulationWorld();
     const edge = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 0.01;
     for (const name of ["One", "Two"] as const) {
@@ -163,13 +197,54 @@ describe("stepHungerTimersWallDelta", () => {
   });
 });
 
+describe("stepHungerTimersSimDayDelta", () => {
+  it("fires hungry then starving in one step when both thresholds are crossed", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        displayName: "Leap",
+        hungerDays: 1.0,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const ev = stepHungerTimersSimDayDelta(world, 2.1);
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish!.fish.hungerDays).toBeCloseTo(3.1, 10);
+    expect(fish!.fish.health).toBe(1);
+    expect(fish!.fish.hungerStage).toBe("starving");
+    expect(ev).toEqual([
+      { kind: "fish_became_hungry", displayName: "Leap" },
+      { kind: "fish_became_starving", displayName: "Leap" },
+    ]);
+  });
+});
+
 describe("resetFishHungerAfterSuccessfulMeal", () => {
-  it("sets hungerDays to zero and hungerStage to healthy", () => {
+  it("sets hungerDays to zero and hungerStage to healthy from hungry", () => {
     const fish = {
       displayName: "A",
       hungerDays: 3.7,
       health: 2 as const,
       hungerStage: "hungry" as const,
+      weightGrams: 100,
+      species: { kind: "herbivore" as const },
+    };
+    resetFishHungerAfterSuccessfulMeal(fish);
+    expect(fish.hungerDays).toBe(0);
+    expect(fish.hungerStage).toBe("healthy");
+  });
+
+  it("sets hungerDays to zero and hungerStage to healthy from starving", () => {
+    const fish = {
+      displayName: "B",
+      hungerDays: 4.2,
+      health: 1 as const,
+      hungerStage: "starving" as const,
       weightGrams: 100,
       species: { kind: "herbivore" as const },
     };

--- a/src/sim/hungerTimer.ts
+++ b/src/sim/hungerTimer.ts
@@ -1,25 +1,27 @@
 import type { World } from "miniplex";
-import { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
+import {
+  FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+} from "./hungerConstants";
 import { wallDeltaToSimDays } from "./simulationClock";
-import type { FishBecameHungryEvent, FishState, SimulationEntity } from "./types";
+import type { FishHungerMilestoneEvent, FishState, SimulationEntity } from "./types";
 import { fishWithKinematics } from "./world";
 
 /**
- * Vitals-adjacent clock: advances each fish's `hungerDays` by the same in-game day
- * delta the simulation clock uses for this wall step (`wallDeltaToSimDays`).
- *
- * When a fish first crosses {@link FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS} while still
- * `healthy`, health drops 3→2, `hungerStage` becomes `"hungry"`, and one event is returned.
+ * Advances each fish's `hungerDays` by `dSim` in-game days and applies hunger
+ * milestones in order (healthy→hungry at 1.5d, hungry→starving at 3d per
+ * `docs/the-game.md`). Each crossing fires at most once, in deterministic order
+ * per fish.
  */
-export function stepHungerTimersWallDelta(
+export function stepHungerTimersSimDayDelta(
   world: World<SimulationEntity>,
-  options: { wallDeltaSeconds: number },
-): readonly FishBecameHungryEvent[] {
-  const dSim = wallDeltaToSimDays(options.wallDeltaSeconds);
+  dSim: number,
+): readonly FishHungerMilestoneEvent[] {
   if (dSim <= 0) return [];
 
-  const events: FishBecameHungryEvent[] = [];
-  const threshold = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS;
+  const events: FishHungerMilestoneEvent[] = [];
+  const firstThreshold = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS;
+  const secondThreshold = SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS;
 
   for (const entity of fishWithKinematics(world)) {
     const fish = entity.fish;
@@ -28,8 +30,8 @@ export function stepHungerTimersWallDelta(
     const after = fish.hungerDays;
 
     if (
-      before < threshold &&
-      after >= threshold &&
+      before < firstThreshold &&
+      after >= firstThreshold &&
       fish.hungerStage === "healthy" &&
       fish.health === 3
     ) {
@@ -37,9 +39,31 @@ export function stepHungerTimersWallDelta(
       fish.hungerStage = "hungry";
       events.push({ kind: "fish_became_hungry", displayName: fish.displayName });
     }
+
+    if (
+      before < secondThreshold &&
+      after >= secondThreshold &&
+      fish.hungerStage === "hungry" &&
+      fish.health === 2
+    ) {
+      fish.health = 1;
+      fish.hungerStage = "starving";
+      events.push({ kind: "fish_became_starving", displayName: fish.displayName });
+    }
   }
 
   return events;
+}
+
+/**
+ * Vitals-adjacent clock: advances each fish's `hungerDays` by the same in-game day
+ * delta the simulation clock uses for this wall step (`wallDeltaToSimDays`).
+ */
+export function stepHungerTimersWallDelta(
+  world: World<SimulationEntity>,
+  options: { wallDeltaSeconds: number },
+): readonly FishHungerMilestoneEvent[] {
+  return stepHungerTimersSimDayDelta(world, wallDeltaToSimDays(options.wallDeltaSeconds));
 }
 
 /** Invoked by interaction systems when a fish successfully eats (food or prey). */

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -1,6 +1,8 @@
 export type {
   FishBecameHungryEvent,
+  FishBecameStarvingEvent,
   FishEntity,
+  FishHungerMilestoneEvent,
   FishHungerStage,
   FishSpeciesTag,
   FishState,
@@ -42,8 +44,14 @@ export {
 export type { SimulationClockState } from "./simulationClock";
 export { stepFishKinematicsWallDelta } from "./movement/fishKinematics";
 export type { StepFishKinematicsOptions } from "./movement/fishKinematics";
-export { FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS } from "./hungerConstants";
-export { dispatchFishBecameHungryEvents, subscribeFishBecameHungryEvents } from "./fishHungerEventBridge";
+export {
+  FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+} from "./hungerConstants";
+export {
+  dispatchFishHungerMilestoneEvents,
+  subscribeFishHungerMilestoneEvents,
+} from "./fishHungerEventBridge";
 export { resetFishHungerAfterSuccessfulMeal, stepHungerTimersWallDelta } from "./hungerTimer";
 export {
   SIMULATION_WORLD_SNAPSHOT_VERSION,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3,14 +3,23 @@ export type Vec3 = { x: number; y: number; z: number };
 
 export type FishSpeciesTag = { kind: "herbivore" } | { kind: "carnivore" };
 
-/** Hunger vitals label; first milestone only (`#7`) — later milestones extend this union. */
-export type FishHungerStage = "healthy" | "hungry";
+/** Hunger vitals label; milestones extend per `docs/the-game.md` (`#7`, `#8`, …). */
+export type FishHungerStage = "healthy" | "hungry" | "starving";
 
 /** Emitted once when a fish crosses the first hunger threshold (healthy → hungry). */
 export type FishBecameHungryEvent = {
   kind: "fish_became_hungry";
   displayName: string;
 };
+
+/** Emitted once when a fish crosses the second hunger threshold (hungry → starving). */
+export type FishBecameStarvingEvent = {
+  kind: "fish_became_starving";
+  displayName: string;
+};
+
+/** Toasts / UI: one entry per hunger milestone crossing in a single hunger step. */
+export type FishHungerMilestoneEvent = FishBecameHungryEvent | FishBecameStarvingEvent;
 
 /**
  * Fish-only simulation fields (movement uses shared `position` / `velocity`).

--- a/src/sim/worldSnapshot.test.ts
+++ b/src/sim/worldSnapshot.test.ts
@@ -106,6 +106,30 @@ describe("simulation world snapshot hooks", () => {
     expect(f!.fish.hungerDays).toBe(2);
   });
 
+  it("deserializes v1 without hungerStage inferring starving when past second threshold", () => {
+    const legacy = {
+      version: SIMULATION_WORLD_SNAPSHOT_VERSION_V1,
+      entities: [
+        {
+          fish: {
+            displayName: "LegacyStarve",
+            hungerDays: 3.5,
+            health: 2,
+            weightGrams: 100,
+            species: { kind: "herbivore" },
+          },
+          position: { x: 0, y: 0.35, z: 0 },
+          velocity: { x: 0, y: 0, z: 0 },
+        },
+      ],
+    };
+    const world = deserializeSimulationWorldSnapshot(legacy);
+    const [f] = [...fishWithKinematics(world)];
+    expect(f!.fish.health).toBe(1);
+    expect(f!.fish.hungerStage).toBe("starving");
+    expect(f!.fish.hungerDays).toBe(3.5);
+  });
+
   it("round-trips optional movementTargetPosition on fish", () => {
     const world = createSimulationWorld();
     const base = assertFishEntityShape({

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -3,7 +3,7 @@ import { useSimulationClock } from "../game/simulationClockContext";
 import { useSimulationWorld } from "../game/simulationWorldContext";
 import {
   clampWallDeltaSeconds,
-  dispatchFishBecameHungryEvents,
+  dispatchFishHungerMilestoneEvents,
   stepFishKinematicsWallDelta,
   stepHungerTimersWallDelta,
 } from "../sim";
@@ -21,7 +21,7 @@ export function SimulationFrameBridge() {
     const dt = clampWallDeltaSeconds(delta);
     stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
     const hungerEvents = stepHungerTimersWallDelta(world, { wallDeltaSeconds: dt });
-    dispatchFishBecameHungryEvents(hungerEvents);
+    dispatchFishHungerMilestoneEvents(hungerEvents);
     advanceByWallDelta(dt);
   });
   return null;


### PR DESCRIPTION
## Linked issue

Closes #8

## Summary

- Second hunger milestone at **3** sim days (`SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS`): health **2→1**, `hungerStage` **starving**, one `fish_became_starving` event per crossing (same pattern as #7).
- `FishHungerStage` and `FishHungerMilestoneEvent` extended; hunger bridge renamed to `subscribeFishHungerMilestoneEvents` / `dispatchFishHungerMilestoneEvents`.
- Core logic in `stepHungerTimersSimDayDelta` (wall path delegates) so two thresholds in one sim step fire hungry then starving in order.
- Guards + v1 snapshot legacy inference for past second threshold.

## Verification

### pnpm test
```

> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-8-hungry-starving
> vitest run


 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-8-hungry-starving


 Test Files  14 passed (14)
      Tests  60 passed (60)
   Start at  22:58:37
   Duration  2.92s (transform 3.77s, setup 491ms, import 6.36s, tests 655ms, environment 13.12s)
```

### pnpm lint
```

> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-8-hungry-starving
> eslint .
```

### pnpm build
```

> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-8-hungry-starving
> tsc -b && vite build

vite v8.0.10 building client environment for production...
^[[2Ktransforming...✓ 59 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.30 kB
dist/assets/index-DranceA6.css     14.51 kB │ gzip:   3.48 kB
dist/assets/index-CLCdDePl.js   1,097.14 kB │ gzip: 301.30 kB

✓ built in 249ms
[plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```

## Visual / interaction tier

**Tier B** — Browser MCP unavailable. Bridge forwards milestone events only; toast copy for starving is #17. Manual later: `pnpm dev`, confirm tank runs without console errors.

## Sub-agent return contract

- Worktree: `/Users/michael/Documents/the-aquarium/.worktrees/issue-8-hungry-starving`
- Branch: `issue-8-hungry-starving`
- Commit: `7fc922d34b66d8a6d295057e05b0e3a90f81593d`
