### PR TITLE
#9 Add hunger threshold transition from starving to dead

### DIFF
--- a/src/sim/entities.test.ts
+++ b/src/sim/entities.test.ts
@@ -13,6 +13,7 @@ import type { FishEntity, FoodEntity, SimulationEntity } from "./index";
 
 const validFishPayload = {
   fish: {
+    alive: true,
     displayName: "Pebble",
     hungerDays: 0,
     health: 3 as const,

--- a/src/sim/guards.ts
+++ b/src/sim/guards.ts
@@ -1,6 +1,7 @@
 import {
   FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
   SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  THIRD_HUNGER_DEATH_THRESHOLD_DAYS,
 } from "./hungerConstants";
 import type {
   FishEntity,
@@ -91,6 +92,9 @@ function collectFishState(path: string, v: unknown): { state: FishState } | { er
   } else if (stageRaw !== undefined) {
     errors.push(`${path}.hungerStage must be "healthy", "hungry", or "starving"`);
   }
+  if (v.alive !== undefined && typeof v.alive !== "boolean") {
+    errors.push(`${path}.alive must be a boolean`);
+  }
   if (errors.length > 0) {
     return { errors };
   }
@@ -100,11 +104,14 @@ function collectFishState(path: string, v: unknown): { state: FishState } | { er
     const hungerDays = v.hungerDays as number;
     if (resolvedHealth === 3 && hungerDays >= FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS) {
       resolvedHealth = 2;
-      hungerStage = "hungry";
-    } else if (resolvedHealth === 2 && hungerDays >= SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS) {
+    }
+    if (resolvedHealth === 2 && hungerDays >= SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS) {
       resolvedHealth = 1;
-      hungerStage = "starving";
-    } else if (resolvedHealth === 3) {
+    }
+    if (resolvedHealth === 1 && hungerDays >= THIRD_HUNGER_DEATH_THRESHOLD_DAYS) {
+      resolvedHealth = 0;
+    }
+    if (resolvedHealth >= 3) {
       hungerStage = "healthy";
     } else if (resolvedHealth === 2) {
       hungerStage = "hungry";
@@ -113,12 +120,23 @@ function collectFishState(path: string, v: unknown): { state: FishState } | { er
     }
   }
 
+  const aliveField = v.alive;
+  const alive =
+    aliveField === false ? false : aliveField === true ? true : resolvedHealth > 0;
+  if (!alive && resolvedHealth !== 0) {
+    return { errors: [`${path}: dead fish must have health 0`] };
+  }
+  if (alive && resolvedHealth === 0) {
+    return { errors: [`${path}: health 0 requires alive false`] };
+  }
+
   return {
     state: {
       displayName: v.displayName as string,
+      alive,
       hungerDays: v.hungerDays as number,
       health: resolvedHealth,
-      hungerStage,
+      hungerStage: hungerStage as FishHungerStage,
       weightGrams: v.weightGrams as number,
       species: species as FishSpeciesTag,
     },

--- a/src/sim/hungerConstants.ts
+++ b/src/sim/hungerConstants.ts
@@ -3,3 +3,6 @@ export const FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS = 1.5 as const;
 
 /** Second hunger milestone from `docs/the-game.md` (hungry → starving, health 2→1). */
 export const SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS = 3 as const;
+
+/** Third hunger milestone from `docs/the-game.md` (starving → death, health 1→0). */
+export const THIRD_HUNGER_DEATH_THRESHOLD_DAYS = 4.5 as const;

--- a/src/sim/hungerTimer.test.ts
+++ b/src/sim/hungerTimer.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
   SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  THIRD_HUNGER_DEATH_THRESHOLD_DAYS,
 } from "./hungerConstants";
 import {
   createSimulationWorld,
@@ -24,6 +25,7 @@ describe("stepHungerTimersWallDelta", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "A",
         hungerDays: 0.5,
         health: 3,
@@ -45,6 +47,7 @@ describe("stepHungerTimersWallDelta", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "A",
         hungerDays: 0,
         health: 3,
@@ -57,6 +60,7 @@ describe("stepHungerTimersWallDelta", () => {
     });
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "B",
         hungerDays: 2,
         health: 2,
@@ -79,6 +83,7 @@ describe("stepHungerTimersWallDelta", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "A",
         hungerDays: 1,
         health: 3,
@@ -99,6 +104,7 @@ describe("stepHungerTimersWallDelta", () => {
     const startBelow = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 0.01;
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "Crosser",
         hungerDays: startBelow,
         health: 3,
@@ -126,6 +132,7 @@ describe("stepHungerTimersWallDelta", () => {
     const startBelow = SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 0.01;
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "Starver",
         hungerDays: startBelow,
         health: 2,
@@ -149,6 +156,7 @@ describe("stepHungerTimersWallDelta", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "Toasty",
         hungerDays: FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS - 1e-6,
         health: 3,
@@ -180,6 +188,7 @@ describe("stepHungerTimersWallDelta", () => {
     for (const name of ["One", "Two"] as const) {
       registerFish(world, {
         fish: {
+          alive: true,
           displayName: name,
           hungerDays: edge,
           health: 3,
@@ -195,6 +204,54 @@ describe("stepHungerTimersWallDelta", () => {
     expect(ev).toHaveLength(2);
     expect(ev.map((e) => e.displayName).sort()).toEqual(["One", "Two"]);
   });
+
+  it("at the third threshold sets health 1→0, alive false, and emits fish_died_starvation once", () => {
+    const world = createSimulationWorld();
+    const startBelow = THIRD_HUNGER_DEATH_THRESHOLD_DAYS - 0.01;
+    registerFish(world, {
+      fish: {
+        alive: true,
+        displayName: "Goner",
+        hungerDays: startBelow,
+        health: 1,
+        hungerStage: "starving",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0.2, y: -0.1, z: 0.05 },
+    });
+    const wallDt = 0.065;
+    const ev = stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt });
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish!.fish.health).toBe(0);
+    expect(fish!.fish.alive).toBe(false);
+    expect(fish!.fish.hungerStage).toBe("starving");
+    expect(ev).toEqual([{ kind: "fish_died_starvation", displayName: "Goner" }]);
+    expect(fish!.velocity.x).toBe(0);
+    expect(fish!.velocity.y).toBe(0);
+    expect(fish!.velocity.z).toBe(0);
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: wallDt })).toEqual([]);
+  });
+
+  it("does not advance hunger for a dead fish", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: false,
+        displayName: "Corpse",
+        hungerDays: 10,
+        health: 0,
+        hungerStage: "starving",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.2, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    expect(stepHungerTimersWallDelta(world, { wallDeltaSeconds: 1 })).toEqual([]);
+    expect([...fishWithKinematics(world)][0]!.fish.hungerDays).toBe(10);
+  });
 });
 
 describe("stepHungerTimersSimDayDelta", () => {
@@ -202,6 +259,7 @@ describe("stepHungerTimersSimDayDelta", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "Leap",
         hungerDays: 1.0,
         health: 3,
@@ -222,11 +280,40 @@ describe("stepHungerTimersSimDayDelta", () => {
       { kind: "fish_became_starving", displayName: "Leap" },
     ]);
   });
+
+  it("fires hungry, starving, and starvation death in one step when all three thresholds are crossed", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: true,
+        displayName: "Cliff",
+        hungerDays: 1.0,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const ev = stepHungerTimersSimDayDelta(world, 4.0);
+    const [fish] = [...fishWithKinematics(world)];
+    expect(fish!.fish.hungerDays).toBeCloseTo(5.0, 10);
+    expect(fish!.fish.health).toBe(0);
+    expect(fish!.fish.alive).toBe(false);
+    expect(fish!.fish.hungerStage).toBe("starving");
+    expect(ev).toEqual([
+      { kind: "fish_became_hungry", displayName: "Cliff" },
+      { kind: "fish_became_starving", displayName: "Cliff" },
+      { kind: "fish_died_starvation", displayName: "Cliff" },
+    ]);
+  });
 });
 
 describe("resetFishHungerAfterSuccessfulMeal", () => {
   it("sets hungerDays to zero and hungerStage to healthy from hungry", () => {
     const fish = {
+      alive: true,
       displayName: "A",
       hungerDays: 3.7,
       health: 2 as const,
@@ -241,6 +328,7 @@ describe("resetFishHungerAfterSuccessfulMeal", () => {
 
   it("sets hungerDays to zero and hungerStage to healthy from starving", () => {
     const fish = {
+      alive: true,
       displayName: "B",
       hungerDays: 4.2,
       health: 1 as const,
@@ -251,5 +339,20 @@ describe("resetFishHungerAfterSuccessfulMeal", () => {
     resetFishHungerAfterSuccessfulMeal(fish);
     expect(fish.hungerDays).toBe(0);
     expect(fish.hungerStage).toBe("healthy");
+  });
+
+  it("is a no-op when the fish is dead", () => {
+    const fish = {
+      alive: false,
+      displayName: "Goner",
+      hungerDays: 9,
+      health: 0 as const,
+      hungerStage: "starving" as const,
+      weightGrams: 100,
+      species: { kind: "herbivore" as const },
+    };
+    resetFishHungerAfterSuccessfulMeal(fish);
+    expect(fish.hungerDays).toBe(9);
+    expect(fish.hungerStage).toBe("starving");
   });
 });

--- a/src/sim/hungerTimer.ts
+++ b/src/sim/hungerTimer.ts
@@ -2,6 +2,7 @@ import type { World } from "miniplex";
 import {
   FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
   SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  THIRD_HUNGER_DEATH_THRESHOLD_DAYS,
 } from "./hungerConstants";
 import { wallDeltaToSimDays } from "./simulationClock";
 import type { FishHungerMilestoneEvent, FishState, SimulationEntity } from "./types";
@@ -9,9 +10,9 @@ import { fishWithKinematics } from "./world";
 
 /**
  * Advances each fish's `hungerDays` by `dSim` in-game days and applies hunger
- * milestones in order (healthy→hungry at 1.5d, hungry→starving at 3d per
- * `docs/the-game.md`). Each crossing fires at most once, in deterministic order
- * per fish.
+ * milestones in order (healthy→hungry at 1.5d, hungry→starving at 3d,
+ * starving→death at 4.5d per `docs/the-game.md`). Each crossing fires at most
+ * once, in deterministic order per fish.
  */
 export function stepHungerTimersSimDayDelta(
   world: World<SimulationEntity>,
@@ -22,9 +23,12 @@ export function stepHungerTimersSimDayDelta(
   const events: FishHungerMilestoneEvent[] = [];
   const firstThreshold = FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS;
   const secondThreshold = SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS;
+  const thirdThreshold = THIRD_HUNGER_DEATH_THRESHOLD_DAYS;
 
   for (const entity of fishWithKinematics(world)) {
     const fish = entity.fish;
+    if (!fish.alive) continue;
+
     const before = fish.hungerDays;
     fish.hungerDays += dSim;
     const after = fish.hungerDays;
@@ -50,6 +54,23 @@ export function stepHungerTimersSimDayDelta(
       fish.hungerStage = "starving";
       events.push({ kind: "fish_became_starving", displayName: fish.displayName });
     }
+
+    if (
+      before < thirdThreshold &&
+      after >= thirdThreshold &&
+      fish.hungerStage === "starving" &&
+      fish.health === 1
+    ) {
+      fish.health = 0;
+      fish.alive = false;
+      events.push({ kind: "fish_died_starvation", displayName: fish.displayName });
+      const v = entity.velocity;
+      if (v) {
+        v.x = 0;
+        v.y = 0;
+        v.z = 0;
+      }
+    }
   }
 
   return events;
@@ -68,6 +89,7 @@ export function stepHungerTimersWallDelta(
 
 /** Invoked by interaction systems when a fish successfully eats (food or prey). */
 export function resetFishHungerAfterSuccessfulMeal(fish: FishState): void {
+  if (!fish.alive) return;
   fish.hungerDays = 0;
   fish.hungerStage = "healthy";
 }

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -1,6 +1,7 @@
 export type {
   FishBecameHungryEvent,
   FishBecameStarvingEvent,
+  FishDiedStarvationEvent,
   FishEntity,
   FishHungerMilestoneEvent,
   FishHungerStage,
@@ -47,6 +48,7 @@ export type { StepFishKinematicsOptions } from "./movement/fishKinematics";
 export {
   FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
   SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
+  THIRD_HUNGER_DEATH_THRESHOLD_DAYS,
 } from "./hungerConstants";
 export {
   dispatchFishHungerMilestoneEvents,

--- a/src/sim/movement/fishKinematics.test.ts
+++ b/src/sim/movement/fishKinematics.test.ts
@@ -7,6 +7,7 @@ import { stepFishKinematicsWallDelta } from "./fishKinematics";
 
 const validFishPayload = {
   fish: {
+    alive: true,
     displayName: "Pebble",
     hungerDays: 0,
     health: 3 as const,
@@ -53,6 +54,33 @@ describe("stepFishKinematicsWallDelta", () => {
       simDays += wallDeltaToSimDays(wallDt);
     }
     expect(distanceSq(fish.position, p0)).toBeLessThan(1e-6);
+  });
+
+  it("does not move a dead fish (idle wander skipped)", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: false,
+        displayName: "Floater",
+        hungerDays: 5,
+        health: 0,
+        hungerStage: "starving",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0.1, y: 0.35, z: -0.05 },
+      velocity: { x: 0.05, y: 0, z: 0 },
+    });
+    const fish = [...fishWithKinematics(world)][0]!;
+    const p0 = { ...fish.position };
+    const wallDt = clampWallDeltaSeconds(1 / 60);
+    for (let i = 0; i < 120; i++) {
+      stepFishKinematicsWallDelta(world, { wallDeltaSeconds: wallDt, simTimeDays: i * wallDeltaToSimDays(wallDt) });
+    }
+    expect(fish.position).toEqual(p0);
+    expect(fish.velocity.x).toBe(0.05);
+    expect(fish.velocity.y).toBe(0);
+    expect(fish.velocity.z).toBe(0);
   });
 
   it("is deterministic for identical step inputs", () => {

--- a/src/sim/movement/fishKinematics.ts
+++ b/src/sim/movement/fishKinematics.ts
@@ -77,6 +77,7 @@ export function stepFishKinematicsWallDelta(
 
   for (const entity of fishWithKinematics(world)) {
     const e = entity as FishKinematicsEntity & SimulationEntity;
+    if (!e.fish.alive) continue;
     if (hasActiveMovementTarget(e)) continue;
 
     const desired = desiredIdleVelocity(e.fish.displayName, simTimeDays);

--- a/src/sim/newRunWorld.ts
+++ b/src/sim/newRunWorld.ts
@@ -14,6 +14,7 @@ export function starterFishEntityForRunSeed(seed: number): FishEntity {
   return {
     fish: {
       displayName: "Pebble",
+      alive: true,
       hungerDays: 0,
       health: 3,
       hungerStage: "healthy",

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -18,8 +18,17 @@ export type FishBecameStarvingEvent = {
   displayName: string;
 };
 
+/** Emitted once when a fish dies of starvation (health 1→0). Reserved for future toasts. */
+export type FishDiedStarvationEvent = {
+  kind: "fish_died_starvation";
+  displayName: string;
+};
+
 /** Toasts / UI: one entry per hunger milestone crossing in a single hunger step. */
-export type FishHungerMilestoneEvent = FishBecameHungryEvent | FishBecameStarvingEvent;
+export type FishHungerMilestoneEvent =
+  | FishBecameHungryEvent
+  | FishBecameStarvingEvent
+  | FishDiedStarvationEvent;
 
 /**
  * Fish-only simulation fields (movement uses shared `position` / `velocity`).
@@ -27,6 +36,8 @@ export type FishHungerMilestoneEvent = FishBecameHungryEvent | FishBecameStarvin
  */
 export type FishState = {
   displayName: string;
+  /** When false, the fish is dead (health 0); hunger does not advance and movement systems skip. */
+  alive: boolean;
   /** Days since last meal; 0 means just ate. */
   hungerDays: number;
   health: 0 | 1 | 2 | 3;

--- a/src/sim/worldSnapshot.test.ts
+++ b/src/sim/worldSnapshot.test.ts
@@ -20,6 +20,7 @@ describe("simulation world snapshot hooks", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "Hungry",
         hungerDays: 1.25,
         health: 3,
@@ -32,6 +33,7 @@ describe("simulation world snapshot hooks", () => {
     });
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "Fed",
         hungerDays: 0,
         health: 3,
@@ -68,6 +70,7 @@ describe("simulation world snapshot hooks", () => {
     const world = createSimulationWorld();
     registerFish(world, {
       fish: {
+        alive: true,
         displayName: "V2",
         hungerDays: 0,
         health: 3,
@@ -104,6 +107,7 @@ describe("simulation world snapshot hooks", () => {
     expect(f!.fish.health).toBe(2);
     expect(f!.fish.hungerStage).toBe("hungry");
     expect(f!.fish.hungerDays).toBe(2);
+    expect(f!.fish.alive).toBe(true);
   });
 
   it("deserializes v1 without hungerStage inferring starving when past second threshold", () => {
@@ -128,12 +132,61 @@ describe("simulation world snapshot hooks", () => {
     expect(f!.fish.health).toBe(1);
     expect(f!.fish.hungerStage).toBe("starving");
     expect(f!.fish.hungerDays).toBe(3.5);
+    expect(f!.fish.alive).toBe(true);
+  });
+
+  it("deserializes v1 without hungerStage inferring starvation death when past third threshold", () => {
+    const legacy = {
+      version: SIMULATION_WORLD_SNAPSHOT_VERSION_V1,
+      entities: [
+        {
+          fish: {
+            displayName: "LegacyDead",
+            hungerDays: 5,
+            health: 1,
+            weightGrams: 100,
+            species: { kind: "herbivore" },
+          },
+          position: { x: 0, y: 0.35, z: 0 },
+          velocity: { x: 0, y: 0, z: 0 },
+        },
+      ],
+    };
+    const world = deserializeSimulationWorldSnapshot(legacy);
+    const [f] = [...fishWithKinematics(world)];
+    expect(f!.fish.health).toBe(0);
+    expect(f!.fish.alive).toBe(false);
+    expect(f!.fish.hungerStage).toBe("starving");
+    expect(f!.fish.hungerDays).toBe(5);
+  });
+
+  it("round-trips starvation death (alive false, health 0)", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: false,
+        displayName: "Floater",
+        hungerDays: 4.51,
+        health: 0,
+        hungerStage: "starving",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.2, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const restored = deserializeSimulationWorldSnapshot(JSON.parse(JSON.stringify(serializeSimulationWorldSnapshot(world))));
+    const [f] = [...fishWithKinematics(restored)];
+    expect(f!.fish.alive).toBe(false);
+    expect(f!.fish.health).toBe(0);
+    expect(f!.fish.hungerDays).toBeCloseTo(4.51, 10);
   });
 
   it("round-trips optional movementTargetPosition on fish", () => {
     const world = createSimulationWorld();
     const base = assertFishEntityShape({
       fish: {
+        alive: true,
         displayName: "Targeted",
         hungerDays: 0.1,
         health: 3,


### PR DESCRIPTION
## Linked issue

Closes #9

## Summary

- Third hunger milestone at **4.5** sim days since last meal: health **1→0**, `alive: false`, velocity zeroed, `fish_died_starvation` milestone event (for future toasts).
- Dead fish: **no** hunger clock advance; **no** idle kinematics (`stepFishKinematicsWallDelta` skips `!fish.alive`).
- `resetFishHungerAfterSuccessfulMeal` no-ops when dead.
- `FishState.alive` + guards (legacy v1 inference includes death path); snapshot round-trip preserves corpse state.

## Visual verification

**Tier C** — simulation-only / no HUD or 3D behavior change beyond existing fish mesh still following the first entity (dead fish remain visible at last position until a future corpse ticket).

## Verification

```text
$ pnpm lint
(eslint — clean)

$ pnpm test
 Test Files  14 passed (14)
      Tests  67 passed (67)

$ pnpm build
✓ built
```

## Return contract

- **Worktree:** `/Users/michael/Documents/the-aquarium/.worktrees/issue-9-starvation-death`
- **Branch:** `issue-9-starvation-death`
- **Commit:** `e75c598` (update if amended)
- **Blockers:** none