### PR TITLE
#19 Add local save snapshot serializer

### DIFF
--- a/src/persistence/index.ts
+++ b/src/persistence/index.ts
@@ -1,0 +1,3 @@
+export { RUN_SNAPSHOT_FORMAT_VERSION, deserializeRunSnapshot, serializeRunSnapshot } from "./runSnapshot";
+export type { DeserializedRunSnapshot, RunSnapshot, SerializeRunSnapshotInput } from "./runSnapshot";
+export { InvalidRunSnapshotError } from "./runSnapshotErrors";

--- a/src/persistence/runSnapshot.test.ts
+++ b/src/persistence/runSnapshot.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSimulationWorld,
+  registerFish,
+  registerFood,
+  fishWithKinematics,
+  foodWithPosition,
+} from "../sim/index";
+import { deserializeRunSnapshot, serializeRunSnapshot } from "./runSnapshot";
+import { InvalidRunSnapshotError } from "./runSnapshotErrors";
+
+describe("run snapshot serializer", () => {
+  it("produces valid JSON (parseable object)", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: true,
+        displayName: "Snap",
+        hungerDays: 0.5,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 120,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0.1, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const snap = serializeRunSnapshot({
+      world,
+      simClockState: { paused: false, simDays: 1.25 },
+    });
+    const json = JSON.stringify(snap);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    expect(parsed.formatVersion).toBe(1);
+    expect(parsed.world).toEqual(expect.objectContaining({ version: 2 }));
+  });
+
+  it("round-trips world entities and simulation clock", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: true,
+        displayName: "Round",
+        hungerDays: 2,
+        health: 2,
+        hungerStage: "hungry",
+        weightGrams: 200,
+        species: { kind: "carnivore" },
+      },
+      position: { x: -0.2, y: 0.4, z: 0.15 },
+      velocity: { x: 0.02, y: 0, z: -0.01 },
+    });
+    registerFood(world, {
+      food: { spawnedAtSimDays: 3 },
+      position: { x: 0, y: 0.55, z: 0 },
+    });
+
+    const clock = { paused: true, simDays: 7.5 };
+    const wire = JSON.stringify(
+      serializeRunSnapshot({
+        world,
+        simClockState: clock,
+        runSeed: 99,
+      }),
+    );
+    const { world: restored, simClockState, runSeed } = deserializeRunSnapshot(JSON.parse(wire));
+
+    expect(simClockState).toEqual(clock);
+    expect(runSeed).toBe(99);
+
+    const [fish] = [...fishWithKinematics(restored)];
+    expect(fish!.fish.displayName).toBe("Round");
+    expect(fish!.fish.hungerDays).toBe(2);
+    expect(fish!.fish.hungerStage).toBe("hungry");
+    expect(fish!.fish.species).toEqual({ kind: "carnivore" });
+    expect(fish!.position.x).toBeCloseTo(-0.2, 10);
+
+    const foods = [...foodWithPosition(restored)];
+    expect(foods).toHaveLength(1);
+    expect(foods[0]!.food.spawnedAtSimDays).toBe(3);
+  });
+
+  it("round-trips without optional runSeed", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      fish: {
+        alive: true,
+        displayName: "NoSeed",
+        hungerDays: 0,
+        health: 3,
+        hungerStage: "healthy",
+        weightGrams: 100,
+        species: { kind: "herbivore" },
+      },
+      position: { x: 0, y: 0.35, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+    });
+    const json = JSON.stringify(
+      serializeRunSnapshot({
+        world,
+        simClockState: { paused: false, simDays: 0 },
+      }),
+    );
+    const { runSeed } = deserializeRunSnapshot(JSON.parse(json));
+    expect(runSeed).toBeUndefined();
+  });
+
+  it("rejects non-object root", () => {
+    expect(() => deserializeRunSnapshot(null)).toThrow(InvalidRunSnapshotError);
+    expect(() => deserializeRunSnapshot("x")).toThrow(InvalidRunSnapshotError);
+  });
+
+  it("rejects unsupported formatVersion", () => {
+    expect(() =>
+      deserializeRunSnapshot({
+        formatVersion: 999,
+        world: { version: 2, entities: [] },
+        simClock: { paused: false, simDays: 0 },
+      }),
+    ).toThrow(InvalidRunSnapshotError);
+  });
+
+  it("rejects invalid simClock shape", () => {
+    expect(() =>
+      deserializeRunSnapshot({
+        formatVersion: 1,
+        world: { version: 2, entities: [] },
+        simClock: { paused: "no", simDays: 0 },
+      }),
+    ).toThrow(InvalidRunSnapshotError);
+  });
+});

--- a/src/persistence/runSnapshot.ts
+++ b/src/persistence/runSnapshot.ts
@@ -1,0 +1,94 @@
+import type { World } from "miniplex";
+import type { SimulationClockState } from "../sim/simulationClock";
+import type { SimulationEntity } from "../sim/types";
+import type { SimulationWorldSnapshot } from "../sim/worldSnapshot";
+import {
+  deserializeSimulationWorldSnapshot,
+  serializeSimulationWorldSnapshot,
+} from "../sim/worldSnapshot";
+import { InvalidRunSnapshotError } from "./runSnapshotErrors";
+
+/** Top-level save envelope; distinct from `SIMULATION_WORLD_SNAPSHOT_VERSION` on nested `world`. */
+export const RUN_SNAPSHOT_FORMAT_VERSION = 1 as const;
+
+export type RunSnapshot = {
+  formatVersion: typeof RUN_SNAPSHOT_FORMAT_VERSION;
+  world: SimulationWorldSnapshot;
+  simClock: SimulationClockState;
+  runSeed?: number;
+};
+
+export type SerializeRunSnapshotInput = {
+  world: World<SimulationEntity>;
+  simClockState: SimulationClockState;
+  /** Persisted for reproducibility (implementation-decisions.md RNG strategy). */
+  runSeed?: number;
+};
+
+export type DeserializedRunSnapshot = {
+  world: World<SimulationEntity>;
+  simClockState: SimulationClockState;
+  runSeed?: number;
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSimClock(value: unknown, path: string): SimulationClockState {
+  if (!isPlainRecord(value)) {
+    throw new InvalidRunSnapshotError([`${path} must be an object`]);
+  }
+  const paused = value.paused;
+  const simDays = value.simDays;
+  if (typeof paused !== "boolean") {
+    throw new InvalidRunSnapshotError([`${path}.paused must be a boolean`]);
+  }
+  if (typeof simDays !== "number" || !Number.isFinite(simDays)) {
+    throw new InvalidRunSnapshotError([`${path}.simDays must be a finite number`]);
+  }
+  return { paused, simDays };
+}
+
+function parseOptionalRunSeed(value: unknown, path: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new InvalidRunSnapshotError([`${path} must be a finite number when present`]);
+  }
+  return value;
+}
+
+/**
+ * Serializes the current run into a JSON-safe structure for `localStorage` or download hooks.
+ * Callers persist with `JSON.stringify(serializeRunSnapshot(...))`.
+ */
+export function serializeRunSnapshot(input: SerializeRunSnapshotInput): RunSnapshot {
+  const base: RunSnapshot = {
+    formatVersion: RUN_SNAPSHOT_FORMAT_VERSION,
+    world: serializeSimulationWorldSnapshot(input.world),
+    simClock: {
+      paused: input.simClockState.paused,
+      simDays: input.simClockState.simDays,
+    },
+  };
+  if (input.runSeed !== undefined) {
+    return { ...base, runSeed: input.runSeed };
+  }
+  return base;
+}
+
+/** Restores a run from `JSON.parse` output of a persisted `serializeRunSnapshot` payload. */
+export function deserializeRunSnapshot(data: unknown): DeserializedRunSnapshot {
+  if (!isPlainRecord(data)) {
+    throw new InvalidRunSnapshotError(["run snapshot root must be an object"]);
+  }
+  if (data.formatVersion !== RUN_SNAPSHOT_FORMAT_VERSION) {
+    throw new InvalidRunSnapshotError([
+      `unsupported run snapshot formatVersion: ${String(data.formatVersion)}`,
+    ]);
+  }
+  const simClock = parseSimClock(data.simClock, "simClock");
+  const world = deserializeSimulationWorldSnapshot(data.world);
+  const runSeed = parseOptionalRunSeed(data.runSeed, "runSeed");
+  return { world, simClockState: simClock, runSeed };
+}

--- a/src/persistence/runSnapshotErrors.ts
+++ b/src/persistence/runSnapshotErrors.ts
@@ -1,0 +1,9 @@
+export class InvalidRunSnapshotError extends Error {
+  readonly messages: readonly string[];
+
+  constructor(messages: readonly string[]) {
+    super(messages.join("; "));
+    this.name = "InvalidRunSnapshotError";
+    this.messages = messages;
+  }
+}


### PR DESCRIPTION
## Linked issue

Closes #19

## Summary

Adds `src/persistence/` with `serializeRunSnapshot` / `deserializeRunSnapshot` that wrap the existing world snapshot (`serializeSimulationWorldSnapshot`) plus `SimulationClockState` and optional `runSeed` for reproducibility per implementation decisions. Output is plain JSON-serializable for `localStorage` and future pause/unload hooks (#20).

## Verification

**Tier C** (pure persistence / no UI)

```text
$ pnpm test src/persistence/runSnapshot.test.ts

 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  6 passed (6)

$ pnpm test

 Test Files  15 passed (15)
      Tests  73 passed (73)

$ pnpm lint

> eslint .

$ pnpm build

✓ built
```

## Sub-agent return contract

1. **Worktree:** `/Users/michael/Documents/the-aquarium/.worktrees/issue-19-save-serializer`
2. **Branch:** `issue-19-save-serializer`
3. **Commit SHA:** `2981d2bfa927ca33af8a5c691a017b00ae05a05e`
4. **PR:** https://github.com/Michael-F-Bryan/the-aquarium/pull/168
5. **Blockers:** none