### PR TITLE
#11 Add nearest-food targeting for starter fish

### DIFF
--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -45,6 +45,7 @@ export {
 export type { SimulationClockState } from "./simulationClock";
 export { stepFishKinematicsWallDelta } from "./movement/fishKinematics";
 export type { StepFishKinematicsOptions } from "./movement/fishKinematics";
+export { updateHerbivoreNearestFoodTargets } from "./targeting/nearestFoodTargeting";
 export {
   FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
   SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,

--- a/src/sim/movement/fishKinematics.test.ts
+++ b/src/sim/movement/fishKinematics.test.ts
@@ -42,18 +42,19 @@ describe("stepFishKinematicsWallDelta", () => {
     expect(distanceSq(fish.position, p0)).toBeGreaterThan(1e-4);
   });
 
-  it("does not idle-wander when movementTargetPosition is set", () => {
+  it("steers toward movementTargetPosition instead of idle wander", () => {
     const world = createSimulationWorld();
     const fish = registerFish(world, validFishPayload);
     (fish as SimulationEntity).movementTargetPosition = { x: 2, y: 0.5, z: -1 };
-    const p0 = { ...fish.position };
+    const p0x = fish.position.x;
     let simDays = 0;
     const wallDt = clampWallDeltaSeconds(1 / 60);
-    for (let i = 0; i < 120; i++) {
+    for (let i = 0; i < 180; i++) {
       stepFishKinematicsWallDelta(world, { wallDeltaSeconds: wallDt, simTimeDays: simDays });
       simDays += wallDeltaToSimDays(wallDt);
     }
-    expect(distanceSq(fish.position, p0)).toBeLessThan(1e-6);
+    expect(fish.position.x).toBeGreaterThan(p0x + 0.05);
+    expect(isWithinStarterSpawnVolume(fish.position)).toBe(true);
   });
 
   it("does not move a dead fish (idle wander skipped)", () => {

--- a/src/sim/movement/fishKinematics.ts
+++ b/src/sim/movement/fishKinematics.ts
@@ -11,6 +11,8 @@ export type StepFishKinematicsOptions = {
 };
 
 const MAX_IDLE_SPEED = 0.32;
+/** Slightly faster than idle wander so flakes are visibly chased (`docs/the-game.md` feeding). */
+const MAX_TARGET_CHASE_SPEED = 0.42;
 const VELOCITY_RESPONSIVENESS = 5.5;
 
 function wanderOffsetFromName(displayName: string): number {
@@ -62,7 +64,7 @@ function desiredIdleVelocity(displayName: string, simTimeDays: number): Vec3 {
 }
 
 /**
- * Movement phase: idle wander for fish with no active movement target.
+ * Movement phase: chase `movementTargetPosition` when set, otherwise idle wander.
  * Mutates ECS `position` / `velocity`; clamped to `STARTER_SPAWN_VOLUME` tank bounds.
  */
 export function stepFishKinematicsWallDelta(
@@ -78,11 +80,37 @@ export function stepFishKinematicsWallDelta(
   for (const entity of fishWithKinematics(world)) {
     const e = entity as FishKinematicsEntity & SimulationEntity;
     if (!e.fish.alive) continue;
-    if (hasActiveMovementTarget(e)) continue;
 
-    const desired = desiredIdleVelocity(e.fish.displayName, simTimeDays);
     const v = e.velocity;
     const p = e.position;
+
+    if (hasActiveMovementTarget(e)) {
+      const target = e.movementTargetPosition!;
+      const toX = target.x - p.x;
+      const toY = target.y - p.y;
+      const toZ = target.z - p.z;
+      const dist = Math.hypot(toX, toY, toZ);
+      if (dist > 1e-6) {
+        const inv = 1 / dist;
+        const desired = {
+          x: toX * inv * MAX_TARGET_CHASE_SPEED,
+          y: toY * inv * MAX_TARGET_CHASE_SPEED,
+          z: toZ * inv * MAX_TARGET_CHASE_SPEED,
+        };
+        v.x += (desired.x - v.x) * blend;
+        v.y += (desired.y - v.y) * blend;
+        v.z += (desired.z - v.z) * blend;
+      }
+
+      p.x += v.x * dt;
+      p.y += v.y * dt;
+      p.z += v.z * dt;
+
+      clampPositionResolveVelocity(p, v);
+      continue;
+    }
+
+    const desired = desiredIdleVelocity(e.fish.displayName, simTimeDays);
 
     v.x += (desired.x - v.x) * blend;
     v.y += (desired.y - v.y) * blend;

--- a/src/sim/targeting/nearestFoodTargeting.test.ts
+++ b/src/sim/targeting/nearestFoodTargeting.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { clampWallDeltaSeconds, wallDeltaToSimDays } from "../simulationClock";
+import { stepFishKinematicsWallDelta } from "../movement/fishKinematics";
+import { createSimulationWorld, fishWithKinematics, registerFish, registerFood } from "../world";
+import type { SimulationEntity } from "../types";
+import { updateHerbivoreNearestFoodTargets } from "./nearestFoodTargeting";
+
+const herbivoreFish = {
+  fish: {
+    alive: true,
+    displayName: "Pebble",
+    hungerDays: 0,
+    health: 3 as const,
+    hungerStage: "healthy" as const,
+    weightGrams: 100,
+    species: { kind: "herbivore" as const },
+  },
+  position: { x: 0, y: 0.35, z: 0 },
+  velocity: { x: 0, y: 0, z: 0 },
+};
+
+describe("updateHerbivoreNearestFoodTargets", () => {
+  it("sets movementTargetPosition to the nearest flake", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 2, y: 0.35, z: 0 } });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.5, y: 0.35, z: 0 } });
+
+    updateHerbivoreNearestFoodTargets(world);
+
+    expect((fish as SimulationEntity).movementTargetPosition).toEqual({ x: 0.5, y: 0.35, z: 0 });
+  });
+
+  it("uses lexicographic flake ordering as a stable tie-break when distances match", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    registerFood(world, { food: { spawnedAtSimDays: 1 }, position: { x: 1, y: 0.35, z: 0 } });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: -1, y: 0.35, z: 0 } });
+
+    updateHerbivoreNearestFoodTargets(world);
+
+    expect((fish as SimulationEntity).movementTargetPosition).toEqual({ x: -1, y: 0.35, z: 0 });
+  });
+
+  it("clears movementTargetPosition when the last flake is removed", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    const flake = registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.8, y: 0.35, z: 0 } });
+
+    updateHerbivoreNearestFoodTargets(world);
+    expect((fish as SimulationEntity).movementTargetPosition).toBeDefined();
+
+    world.remove(flake);
+    updateHerbivoreNearestFoodTargets(world);
+
+    expect((fish as SimulationEntity).movementTargetPosition).toBeUndefined();
+  });
+
+  it("does not set food targets on carnivores", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, displayName: "Chomper", species: { kind: "carnivore" } },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.2, y: 0.35, z: 0 } });
+
+    updateHerbivoreNearestFoodTargets(world);
+
+    expect((fish as SimulationEntity).movementTargetPosition).toBeUndefined();
+  });
+
+  it("retargets when a closer flake exists than the previous nearest", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 3, y: 0.35, z: 0 } });
+    updateHerbivoreNearestFoodTargets(world);
+    expect((fish as SimulationEntity).movementTargetPosition?.x).toBeCloseTo(3, 5);
+
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.2, y: 0.35, z: 0 } });
+    updateHerbivoreNearestFoodTargets(world);
+    expect((fish as SimulationEntity).movementTargetPosition?.x).toBeCloseTo(0.2, 5);
+  });
+
+  it("skips dead herbivores", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, alive: false, health: 0, hungerStage: "starving" },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.2, y: 0.35, z: 0 } });
+
+    updateHerbivoreNearestFoodTargets(world);
+
+    expect([...fishWithKinematics(world)][0]).toBe(fish);
+    expect((fish as SimulationEntity).movementTargetPosition).toBeUndefined();
+  });
+
+  it("combined with kinematics moves the fish toward the targeted flake", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 1.5, y: 0.35, z: 0 } });
+    const startX = fish.position.x;
+    const wallDt = clampWallDeltaSeconds(1 / 60);
+    let simDays = 0;
+    for (let i = 0; i < 240; i++) {
+      updateHerbivoreNearestFoodTargets(world);
+      stepFishKinematicsWallDelta(world, { wallDeltaSeconds: wallDt, simTimeDays: simDays });
+      simDays += wallDeltaToSimDays(wallDt);
+    }
+    expect(fish.position.x).toBeGreaterThan(startX + 0.08);
+  });
+});

--- a/src/sim/targeting/nearestFoodTargeting.ts
+++ b/src/sim/targeting/nearestFoodTargeting.ts
@@ -1,0 +1,62 @@
+import type { World } from "miniplex";
+import type { SimulationEntity, Vec3 } from "../types";
+import { fishWithKinematics, foodWithPosition } from "../world";
+
+function distanceSquared(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
+/**
+ * Deterministic ordering when two flakes are equally far: lexicographic `position`,
+ * then `spawnedAtSimDays` (mirrors stable array / id tie-break intent in issue #11).
+ */
+function compareFoodTieBreak(a: SimulationEntity, b: SimulationEntity): number {
+  const pa = a.position;
+  const pb = b.position;
+  if (pa.x !== pb.x) return pa.x - pb.x;
+  if (pa.y !== pb.y) return pa.y - pb.y;
+  if (pa.z !== pb.z) return pa.z - pb.z;
+  return (a.food?.spawnedAtSimDays ?? 0) - (b.food?.spawnedAtSimDays ?? 0);
+}
+
+/**
+ * Sets `movementTargetPosition` on living herbivores to the nearest food flake,
+ * or clears it when no food exists. Carnivores are left untouched (prey targeting is separate).
+ * Call each tick while unpaused, after food positions are authoritative and before kinematics.
+ */
+export function updateHerbivoreNearestFoodTargets(world: World<SimulationEntity>): void {
+  const foods = [...foodWithPosition(world)] as SimulationEntity[];
+  foods.sort(compareFoodTieBreak);
+
+  for (const entity of fishWithKinematics(world)) {
+    const e = entity as SimulationEntity;
+    if (!e.fish?.alive) continue;
+    if (e.fish.species.kind !== "herbivore") continue;
+
+    if (foods.length === 0) {
+      delete e.movementTargetPosition;
+      continue;
+    }
+
+    let bestD2 = Infinity;
+    let bestRank = Infinity;
+    let best: Vec3 | undefined;
+
+    const fp = e.position;
+    for (let rank = 0; rank < foods.length; rank++) {
+      const food = foods[rank]!;
+      const d2 = distanceSquared(fp, food.position);
+      if (d2 < bestD2 || (d2 === bestD2 && rank < bestRank)) {
+        bestD2 = d2;
+        bestRank = rank;
+        best = food.position;
+      }
+    }
+
+    const chosen = best!;
+    e.movementTargetPosition = { x: chosen.x, y: chosen.y, z: chosen.z };
+  }
+}

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -6,6 +6,7 @@ import {
   dispatchFishHungerMilestoneEvents,
   stepFishKinematicsWallDelta,
   stepHungerTimersWallDelta,
+  updateHerbivoreNearestFoodTargets,
 } from "../sim";
 
 /**
@@ -19,6 +20,7 @@ export function SimulationFrameBridge() {
   useFrame((_, delta) => {
     if (paused) return;
     const dt = clampWallDeltaSeconds(delta);
+    updateHerbivoreNearestFoodTargets(world);
     stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
     const hungerEvents = stepHungerTimersWallDelta(world, { wallDeltaSeconds: dt });
     dispatchFishHungerMilestoneEvents(hungerEvents);


### PR DESCRIPTION
Closes #11

## Summary
- Herbivore fish get `movementTargetPosition` from nearest food (squared distance; deterministic tie-break).
- Clears target when no food; carnivores unchanged for future prey targeting.
- Kinematics chase toward target with capped speed.

## Visual QA (Tier B)
Browser MCP unavailable in implementer session — manual: `pnpm dev`, drop food via tank click, observe fish motion bias toward drop; pause stops updates.

## Verification
See CI + local: `pnpm test` (15 files, 74 tests), `pnpm lint`, `pnpm build` green before push.