### PR TITLE
#20 Add local save snapshot restore on boot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
+import { RunSnapshotPersistenceEffect } from "./game/RunSnapshotPersistenceEffect";
 import { SimulationClockProvider } from "./game/SimulationClockProvider";
 import { SimulationWorldProvider } from "./game/SimulationWorldProvider";
 import { useSimulationClock } from "./game/simulationClockContext";
+import { loadRunBootstrapFromLocalStorage } from "./persistence/runSnapshotStorage";
 import { TankScene } from "./tank/TankScene";
 import { DayCounter } from "./ui/DayCounter";
 import { ScorePlaceholder } from "./ui/ScorePlaceholder";
@@ -42,9 +45,11 @@ function GameShell() {
 }
 
 export default function App() {
+  const [bootstrap] = useState(() => loadRunBootstrapFromLocalStorage());
   return (
-    <SimulationClockProvider>
-      <SimulationWorldProvider>
+    <SimulationClockProvider initialClockState={bootstrap.simClockState}>
+      <SimulationWorldProvider runSeed={bootstrap.runSeed} world={bootstrap.world}>
+        <RunSnapshotPersistenceEffect />
         <GameShell />
       </SimulationWorldProvider>
     </SimulationClockProvider>

--- a/src/game/RunSnapshotPersistenceEffect.tsx
+++ b/src/game/RunSnapshotPersistenceEffect.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { saveRunSnapshotToLocalStorage } from "../persistence/runSnapshotStorage";
+import { useSimulationClock } from "./simulationClockContext";
+import { useSimulationWorld } from "./simulationWorldContext";
+
+/** Best-effort persist of the active run so refresh restores continuity (issue #20). */
+export function RunSnapshotPersistenceEffect() {
+  const { world, runSeed } = useSimulationWorld();
+  const { paused, simDays } = useSimulationClock();
+
+  useEffect(() => {
+    const flush = () => {
+      saveRunSnapshotToLocalStorage({
+        world,
+        simClockState: { paused, simDays },
+        runSeed,
+      });
+    };
+    window.addEventListener("pagehide", flush);
+    window.addEventListener("beforeunload", flush);
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      window.removeEventListener("beforeunload", flush);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [world, paused, simDays, runSeed]);
+
+  return null;
+}

--- a/src/game/SimulationClockProvider.tsx
+++ b/src/game/SimulationClockProvider.tsx
@@ -4,8 +4,15 @@ import { SimulationClockContext, type SimulationClockContextValue } from "./simu
 
 const initialClock: SimulationClockState = { paused: false, simDays: 0 };
 
-export function SimulationClockProvider({ children }: { children: ReactNode }) {
-  const [clock, setClock] = useState<SimulationClockState>(initialClock);
+export function SimulationClockProvider({
+  children,
+  initialClockState = initialClock,
+}: {
+  children: ReactNode;
+  /** Hydration from persisted run snapshot (issue #20). */
+  initialClockState?: SimulationClockState;
+}) {
+  const [clock, setClock] = useState<SimulationClockState>(initialClockState);
 
   const advanceByWallDelta = useCallback((deltaWallSeconds: number) => {
     setClock((c) => advanceClockByWallDelta(c, deltaWallSeconds));

--- a/src/game/SimulationWorldProvider.tsx
+++ b/src/game/SimulationWorldProvider.tsx
@@ -8,13 +8,19 @@ export type SimulationWorldProviderProps = {
   children: ReactNode;
   /** Simulation RNG / starter baseline; default is deterministic across loads. */
   runSeed?: number;
+  /** When set (e.g. restore), this world is used instead of creating a new run. */
+  world?: World<SimulationEntity>;
 };
 
-export function SimulationWorldProvider({ children, runSeed = DEFAULT_SIMULATION_SEED }: SimulationWorldProviderProps) {
+export function SimulationWorldProvider({
+  children,
+  runSeed = DEFAULT_SIMULATION_SEED,
+  world: worldProp,
+}: SimulationWorldProviderProps) {
   const value = useMemo((): { world: World<SimulationEntity>; runSeed: number } => {
-    const world = createNewRunSimulationWorld(runSeed);
+    const world = worldProp ?? createNewRunSimulationWorld(runSeed);
     return { world, runSeed };
-  }, [runSeed]);
+  }, [worldProp, runSeed]);
 
   return <SimulationWorldContext.Provider value={value}>{children}</SimulationWorldContext.Provider>;
 }

--- a/src/persistence/index.ts
+++ b/src/persistence/index.ts
@@ -1,3 +1,9 @@
 export { RUN_SNAPSHOT_FORMAT_VERSION, deserializeRunSnapshot, serializeRunSnapshot } from "./runSnapshot";
 export type { DeserializedRunSnapshot, RunSnapshot, SerializeRunSnapshotInput } from "./runSnapshot";
 export { InvalidRunSnapshotError } from "./runSnapshotErrors";
+export {
+  RUN_SNAPSHOT_STORAGE_KEY,
+  loadRunBootstrapFromLocalStorage,
+  saveRunSnapshotToLocalStorage,
+} from "./runSnapshotStorage";
+export type { RunBootstrapSnapshot } from "./runSnapshotStorage";

--- a/src/persistence/runSnapshotStorage.test.ts
+++ b/src/persistence/runSnapshotStorage.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNewRunSimulationWorld, DEFAULT_SIMULATION_SEED } from "../sim/newRunWorld";
+import { serializeRunSnapshot } from "./runSnapshot";
+import {
+  RUN_SNAPSHOT_STORAGE_KEY,
+  loadRunBootstrapFromLocalStorage,
+  saveRunSnapshotToLocalStorage,
+} from "./runSnapshotStorage";
+
+const initialClock = { paused: false, simDays: 0 };
+
+function mockLocalStorage() {
+  let store: Record<string, string> = {};
+  const ls = {
+    getItem: vi.fn((k: string) => (k in store ? store[k] : null)),
+    setItem: vi.fn((k: string, v: string) => {
+      store[k] = v;
+    }),
+    removeItem: vi.fn((k: string) => {
+      delete store[k];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+  vi.stubGlobal("localStorage", ls as unknown as Storage);
+  return { ls, get store() {
+    return store;
+  } };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("RUN_SNAPSHOT_STORAGE_KEY", () => {
+  it("matches design constant", () => {
+    expect(RUN_SNAPSHOT_STORAGE_KEY).toBe("the-aquarium.run.v1");
+  });
+});
+
+describe("loadRunBootstrapFromLocalStorage", () => {
+  it("returns new run when key missing", () => {
+    mockLocalStorage();
+    const got = loadRunBootstrapFromLocalStorage();
+    expect(got.runSeed).toBe(DEFAULT_SIMULATION_SEED);
+    expect(got.simClockState).toEqual(initialClock);
+    expect(got.world.entities).toHaveLength(1);
+  });
+
+  it("restores world and clock from valid snapshot", () => {
+    const { ls } = mockLocalStorage();
+    const world = createNewRunSimulationWorld(99);
+    world.entities[0]!.fish!.hungerDays = 1.5;
+    const json = JSON.stringify(
+      serializeRunSnapshot({
+        world,
+        simClockState: { paused: true, simDays: 2.25 },
+        runSeed: 99,
+      }),
+    );
+    ls.getItem.mockImplementation((k: string) => (k === RUN_SNAPSHOT_STORAGE_KEY ? json : null));
+
+    const got = loadRunBootstrapFromLocalStorage();
+    expect(got.runSeed).toBe(99);
+    expect(got.simClockState).toEqual({ paused: true, simDays: 2.25 });
+    expect(got.world.entities).toHaveLength(1);
+    expect(got.world.entities[0]!.fish!.hungerDays).toBe(1.5);
+  });
+
+  it("falls back on invalid JSON without throwing", () => {
+    const { ls } = mockLocalStorage();
+    ls.getItem.mockImplementation((k: string) => (k === RUN_SNAPSHOT_STORAGE_KEY ? "{not-json" : null));
+
+    expect(() => loadRunBootstrapFromLocalStorage()).not.toThrow();
+    const got = loadRunBootstrapFromLocalStorage();
+    expect(got.runSeed).toBe(DEFAULT_SIMULATION_SEED);
+    expect(got.simClockState).toEqual(initialClock);
+  });
+
+  it("falls back on InvalidRunSnapshotError", () => {
+    const { ls } = mockLocalStorage();
+    ls.getItem.mockImplementation((k: string) =>
+      k === RUN_SNAPSHOT_STORAGE_KEY ? JSON.stringify({ formatVersion: 999 }) : null,
+    );
+
+    const got = loadRunBootstrapFromLocalStorage();
+    expect(got.runSeed).toBe(DEFAULT_SIMULATION_SEED);
+  });
+
+  it("falls back on bad entity data inside snapshot", () => {
+    const { ls } = mockLocalStorage();
+    ls.getItem.mockImplementation((k: string) =>
+      k === RUN_SNAPSHOT_STORAGE_KEY
+        ? JSON.stringify({
+            formatVersion: 1,
+            simClock: { paused: false, simDays: 0 },
+            world: { version: 2, entities: [{ fish: { not: "a fish" } }] },
+          })
+        : null,
+    );
+
+    const got = loadRunBootstrapFromLocalStorage();
+    expect(got.world.entities.length).toBeGreaterThanOrEqual(1);
+    expect(got.runSeed).toBe(DEFAULT_SIMULATION_SEED);
+  });
+});
+
+describe("saveRunSnapshotToLocalStorage", () => {
+  it("writes JSON envelope for current world", () => {
+    const { store } = mockLocalStorage();
+    const world = createNewRunSimulationWorld(7);
+    saveRunSnapshotToLocalStorage({
+      world,
+      simClockState: { paused: false, simDays: 3 },
+      runSeed: 7,
+    });
+    const raw = store[RUN_SNAPSHOT_STORAGE_KEY];
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.formatVersion).toBe(1);
+    expect(parsed.runSeed).toBe(7);
+    expect(parsed.simClock.simDays).toBe(3);
+  });
+});

--- a/src/persistence/runSnapshotStorage.ts
+++ b/src/persistence/runSnapshotStorage.ts
@@ -1,0 +1,72 @@
+import type { World } from "miniplex";
+import { createNewRunSimulationWorld, DEFAULT_SIMULATION_SEED } from "../sim/newRunWorld";
+import type { SimulationClockState } from "../sim/simulationClock";
+import type { SimulationEntity } from "../sim/types";
+import { deserializeRunSnapshot, serializeRunSnapshot, type SerializeRunSnapshotInput } from "./runSnapshot";
+
+/** Stable `localStorage` key for run snapshot JSON (implementation-decisions.md). */
+export const RUN_SNAPSHOT_STORAGE_KEY = "the-aquarium.run.v1" as const;
+
+const defaultClock: SimulationClockState = { paused: false, simDays: 0 };
+
+export type RunBootstrapSnapshot = {
+  world: World<SimulationEntity>;
+  simClockState: SimulationClockState;
+  runSeed: number;
+};
+
+function newRunBootstrap(): RunBootstrapSnapshot {
+  const runSeed = DEFAULT_SIMULATION_SEED;
+  return {
+    world: createNewRunSimulationWorld(runSeed),
+    simClockState: { ...defaultClock },
+    runSeed,
+  };
+}
+
+/**
+ * Reads persisted run state from `localStorage`. On missing, corrupt JSON, or invalid snapshot
+ * shape, returns a fresh run (never throws to the caller).
+ */
+export function loadRunBootstrapFromLocalStorage(): RunBootstrapSnapshot {
+  if (typeof localStorage === "undefined") {
+    return newRunBootstrap();
+  }
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(RUN_SNAPSHOT_STORAGE_KEY);
+  } catch {
+    return newRunBootstrap();
+  }
+  if (raw == null || raw === "") {
+    return newRunBootstrap();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return newRunBootstrap();
+  }
+  try {
+    const { world, simClockState, runSeed } = deserializeRunSnapshot(parsed);
+    return {
+      world,
+      simClockState,
+      runSeed: runSeed ?? DEFAULT_SIMULATION_SEED,
+    };
+  } catch {
+    return newRunBootstrap();
+  }
+}
+
+/** Persists the current run for restore on next load (best-effort; ignores quota / access errors). */
+export function saveRunSnapshotToLocalStorage(input: SerializeRunSnapshotInput): void {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+  try {
+    localStorage.setItem(RUN_SNAPSHOT_STORAGE_KEY, JSON.stringify(serializeRunSnapshot(input)));
+  } catch {
+    // QuotaExceededError, SecurityError, etc.
+  }
+}


### PR DESCRIPTION
## Linked issue

Closes #20

## Summary

- Add `RUN_SNAPSHOT_STORAGE_KEY` (`the-aquarium.run.v1`) and `loadRunBootstrapFromLocalStorage` / `saveRunSnapshotToLocalStorage` in `src/persistence/runSnapshotStorage.ts`, using `deserializeRunSnapshot` / `serializeRunSnapshot`.
- App boot: `useState(() => loadRunBootstrapFromLocalStorage())` hydrates `SimulationClockProvider` and passes `world` + `runSeed` into `SimulationWorldProvider`.
- Invalid or missing snapshot falls back to a new run without throwing through the React tree; `JSON.parse` and deserialization errors are contained inside the loader.
- `RunSnapshotPersistenceEffect` flushes on `pagehide`, `beforeunload`, and `visibilitychange` (hidden) so dev refresh keeps continuity once a snapshot has been written.

## Visual / interaction verification

**Tier B** — Browser MCP unavailable—manual only.

Boot checklist:

- [ ] `pnpm dev`, load app: tank and HUD render (no blank screen).
- [ ] Play briefly, refresh: prior `simDays` / pause / fish state roughly restored (after at least one visibility hide or navigation away so flush ran).
- [ ] DevTools → Application → Local Storage: delete `the-aquarium.run.v1`, hard refresh: fresh run (default seed, day 0).
- [ ] Set `the-aquarium.run.v1` to `{not-json` and refresh: app still loads a new run (no crash).

## Verification

### `pnpm test`

```

> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-20-save-restore
> vitest run


 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-20-save-restore


 Test Files  17 passed (17)
      Tests  87 passed (87)
   Start at  23:21:53
   Duration  2.97s (transform 1.13s, setup 715ms, import 1.94s, tests 736ms, environment 16.31s)

```

### `pnpm lint`

```

> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-20-save-restore
> eslint .

```

### `pnpm build`

```

> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-20-save-restore
> tsc -b && vite build

vite v8.0.10 building client environment for production...
transforming...✓ 64 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.31 kB
dist/assets/index-CUh0QDYJ.css     14.54 kB │ gzip:   3.49 kB
dist/assets/index-ms8T1V4s.js   1,101.91 kB │ gzip: 302.69 kB

✓ built in 260ms
[plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```
