### PR TITLE
#12 Add eat interaction to consume nearby food

### DIFF
--- a/src/sim/fishEatFoodEventBridge.ts
+++ b/src/sim/fishEatFoodEventBridge.ts
@@ -1,0 +1,21 @@
+import type { FishAteFoodEvent } from "./types";
+
+const listeners = new Set<(events: readonly FishAteFoodEvent[]) => void>();
+
+/** Register a consumer (e.g. toast shell). Returns an unsubscribe function. */
+export function subscribeFishAteFoodEvents(
+  listener: (events: readonly FishAteFoodEvent[]) => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Invoked after each eat step with events from that step only (one per flake consumed). */
+export function dispatchFishAteFoodEvents(events: readonly FishAteFoodEvent[]): void {
+  if (events.length === 0) return;
+  for (const listener of [...listeners]) {
+    listener(events);
+  }
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -1,4 +1,5 @@
 export type {
+  FishAteFoodEvent,
   FishBecameHungryEvent,
   FishBecameStarvingEvent,
   FishDiedStarvationEvent,
@@ -45,7 +46,18 @@ export {
 export type { SimulationClockState } from "./simulationClock";
 export { stepFishKinematicsWallDelta } from "./movement/fishKinematics";
 export type { StepFishKinematicsOptions } from "./movement/fishKinematics";
-export { updateHerbivoreNearestFoodTargets } from "./targeting/nearestFoodTargeting";
+export {
+  compareFoodEntitiesStableTieBreak,
+  updateHerbivoreNearestFoodTargets,
+} from "./targeting/nearestFoodTargeting";
+export {
+  HERBIVORE_FOOD_EAT_DISTANCE,
+  stepHerbivoreEatNearbyFood,
+} from "./interactions/herbivoreEatNearbyFood";
+export {
+  dispatchFishAteFoodEvents,
+  subscribeFishAteFoodEvents,
+} from "./fishEatFoodEventBridge";
 export {
   FIRST_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,
   SECOND_HUNGER_HEALTH_LOSS_THRESHOLD_DAYS,

--- a/src/sim/interactions/herbivoreEatNearbyFood.test.ts
+++ b/src/sim/interactions/herbivoreEatNearbyFood.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSimulationWorld, registerFish, registerFood } from "../world";
+import { dispatchFishAteFoodEvents, subscribeFishAteFoodEvents } from "../fishEatFoodEventBridge";
+import { HERBIVORE_FOOD_EAT_DISTANCE, stepHerbivoreEatNearbyFood } from "./herbivoreEatNearbyFood";
+
+const herbivoreFish = {
+  fish: {
+    displayName: "Seed",
+    alive: true,
+    hungerDays: 1.2,
+    health: 3 as const,
+    hungerStage: "healthy" as const,
+    weightGrams: 100,
+    species: { kind: "herbivore" as const },
+  },
+  position: { x: 0, y: 0.35, z: 0 },
+  velocity: { x: 0, y: 0, z: 0 },
+};
+
+describe("stepHerbivoreEatNearbyFood", () => {
+  it("returns no events and mutates nothing when paused", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0, y: 0.35, z: 0 } });
+    const ev = stepHerbivoreEatNearbyFood(world, { paused: true });
+    expect(ev).toEqual([]);
+    expect([...world.with("food", "position").connect()]).toHaveLength(1);
+    expect((fish as { hungerDays: number }).fish.hungerDays).toBeCloseTo(1.2, 5);
+  });
+
+  it("removes food, resets hunger, clears movement target, and emits one event per flake", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    (fish as { movementTargetPosition?: { x: number; y: number; z: number } }).movementTargetPosition = {
+      x: 0.05,
+      y: 0.35,
+      z: 0,
+    };
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.05, y: 0.35, z: 0 } });
+
+    const ev = stepHerbivoreEatNearbyFood(world, { paused: false });
+    expect(ev).toEqual([{ kind: "fish_ate_food", displayName: "Seed" }]);
+    expect([...world.with("food", "position").connect()]).toHaveLength(0);
+    expect(fish.fish.hungerDays).toBe(0);
+    expect(fish.fish.hungerStage).toBe("healthy");
+    expect((fish as { movementTargetPosition?: unknown }).movementTargetPosition).toBeUndefined();
+  });
+
+  it("fires eat dispatch exactly once per returned event", () => {
+    const world = createSimulationWorld();
+    registerFish(world, herbivoreFish);
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0, y: 0.35, z: 0 } });
+    const spy = vi.fn();
+    const unsub = subscribeFishAteFoodEvents(spy);
+    dispatchFishAteFoodEvents(stepHerbivoreEatNearbyFood(world, { paused: false }));
+    unsub();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]![0]).toEqual([{ kind: "fish_ate_food", displayName: "Seed" }]);
+  });
+
+  it("does not emit when dispatch receives an empty list", () => {
+    const spy = vi.fn();
+    const unsub = subscribeFishAteFoodEvents(spy);
+    dispatchFishAteFoodEvents([]);
+    unsub();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("when two flakes are in range, prefers the one matching movementTargetPosition", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, herbivoreFish);
+    (fish as { movementTargetPosition?: { x: number; y: number; z: number } }).movementTargetPosition = {
+      x: 0.08,
+      y: 0.35,
+      z: 0,
+    };
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.08, y: 0.35, z: 0 } });
+    registerFood(world, { food: { spawnedAtSimDays: 1 }, position: { x: 0.06, y: 0.35, z: 0 } });
+
+    stepHerbivoreEatNearbyFood(world, { paused: false });
+    const remaining = [...world.with("food", "position").connect()];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.position.x).toBeCloseTo(0.06, 5);
+  });
+
+  it("when no movement target, picks closest flake with stable food tie-break", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      ...herbivoreFish,
+      position: { x: 0, y: 0.35, z: 0 },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 1 }, position: { x: 0.1, y: 0.35, z: 0 } });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: -0.1, y: 0.35, z: 0 } });
+    stepHerbivoreEatNearbyFood(world, { paused: false });
+    const remaining = [...world.with("food", "position").connect()];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.food.spawnedAtSimDays).toBe(1);
+  });
+
+  it("two fish and one flake: deterministic fish order — only one eats", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, displayName: "B" },
+      position: { x: 0, y: 0.35, z: 0 },
+    });
+    registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, displayName: "A" },
+      position: { x: 0.02, y: 0.35, z: 0 },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0.01, y: 0.35, z: 0 } });
+    const ev = stepHerbivoreEatNearbyFood(world, { paused: false });
+    expect(ev).toHaveLength(1);
+    expect(ev[0]!.displayName).toBe("A");
+    expect([...world.with("food", "position").connect()]).toHaveLength(0);
+  });
+
+  it("skips dead herbivores and carnivores", () => {
+    const world = createSimulationWorld();
+    registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, alive: false, health: 0, hungerStage: "starving" },
+    });
+    registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, displayName: "Chomper", species: { kind: "carnivore" } },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0, y: 0.35, z: 0 } });
+    expect(stepHerbivoreEatNearbyFood(world, { paused: false })).toEqual([]);
+    expect([...world.with("food", "position").connect()]).toHaveLength(1);
+  });
+
+  it("does not eat when just outside threshold", () => {
+    const world = createSimulationWorld();
+    registerFish(world, herbivoreFish);
+    const dx = HERBIVORE_FOOD_EAT_DISTANCE + 0.02;
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: dx, y: 0.35, z: 0 } });
+    expect(stepHerbivoreEatNearbyFood(world, { paused: false })).toEqual([]);
+    expect([...world.with("food", "position").connect()]).toHaveLength(1);
+  });
+});

--- a/src/sim/interactions/herbivoreEatNearbyFood.ts
+++ b/src/sim/interactions/herbivoreEatNearbyFood.ts
@@ -1,0 +1,115 @@
+import type { World } from "miniplex";
+import { compareFoodEntitiesStableTieBreak } from "../targeting/nearestFoodTargeting";
+import { resetFishHungerAfterSuccessfulMeal } from "../hungerTimer";
+import type { FishAteFoodEvent, SimulationEntity, Vec3 } from "../types";
+import { fishWithKinematics, foodWithPosition } from "../world";
+
+/** World-space mouth reach: fish snaps up a flake when centers are within this distance. */
+export const HERBIVORE_FOOD_EAT_DISTANCE = 0.12;
+
+const eatDistanceSquared = HERBIVORE_FOOD_EAT_DISTANCE * HERBIVORE_FOOD_EAT_DISTANCE;
+
+/**
+ * When `movementTargetPosition` is copied from a flake center, this squared epsilon
+ * treats the flake as the intended target even after tiny kinematic drift.
+ */
+const MOVEMENT_TARGET_MATCH_EPSILON_SQ = 1e-10;
+
+function distanceSquared(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
+function compareHerbivoreFishStable(a: SimulationEntity, b: SimulationEntity): number {
+  const fa = a.fish!;
+  const fb = b.fish!;
+  if (fa.displayName !== fb.displayName) {
+    return fa.displayName < fb.displayName ? -1 : 1;
+  }
+  const pa = a.position;
+  const pb = b.position;
+  if (pa.x !== pb.x) return pa.x - pb.x;
+  if (pa.y !== pb.y) return pa.y - pb.y;
+  return pa.z - pb.z;
+}
+
+function sortedLivingHerbivores(world: World<SimulationEntity>): SimulationEntity[] {
+  const out: SimulationEntity[] = [];
+  for (const entity of fishWithKinematics(world)) {
+    const e = entity as SimulationEntity;
+    if (!e.fish?.alive || e.fish.species.kind !== "herbivore") continue;
+    out.push(e);
+  }
+  out.sort(compareHerbivoreFishStable);
+  return out;
+}
+
+type FoodCandidate = {
+  entity: SimulationEntity;
+  d2Fish: number;
+  rank: number;
+  d2Target: number;
+};
+
+/**
+ * Among flakes within eat distance, prefer the flake matching `movementTargetPosition`
+ * (same tie-break ordering as targeting when several match). Otherwise choose closest
+ * to the fish, breaking ties by stable food sort rank.
+ */
+function pickFoodToEat(
+  fishPosition: Vec3,
+  foodsSorted: SimulationEntity[],
+  movementTarget: Vec3 | undefined,
+): SimulationEntity | undefined {
+  const candidates: FoodCandidate[] = [];
+  for (let rank = 0; rank < foodsSorted.length; rank++) {
+    const entity = foodsSorted[rank]!;
+    const d2Fish = distanceSquared(fishPosition, entity.position);
+    if (d2Fish > eatDistanceSquared) continue;
+    const d2Target =
+      movementTarget === undefined ? Number.POSITIVE_INFINITY : distanceSquared(entity.position, movementTarget);
+    candidates.push({ entity, d2Fish, rank, d2Target });
+  }
+  if (candidates.length === 0) return undefined;
+
+  const onTarget = candidates.filter((c) => c.d2Target <= MOVEMENT_TARGET_MATCH_EPSILON_SQ);
+  const pool = onTarget.length > 0 ? onTarget : candidates;
+
+  let best = pool[0]!;
+  for (let i = 1; i < pool.length; i++) {
+    const c = pool[i]!;
+    if (c.d2Fish < best.d2Fish || (c.d2Fish === best.d2Fish && c.rank < best.rank)) {
+      best = c;
+    }
+  }
+  return best.entity;
+}
+
+/**
+ * Interaction phase: living herbivores within eat distance consume one flake each
+ * (deterministic fish order, deterministic food tie-break). Clears movement target,
+ * resets hunger, removes the food entity, and returns one `fish_ate_food` event per flake.
+ * No-op while paused (callers should skip when paused; flag kept for tests and parity with `tryDropFoodAt`).
+ */
+export function stepHerbivoreEatNearbyFood(
+  world: World<SimulationEntity>,
+  options: { paused: boolean },
+): readonly FishAteFoodEvent[] {
+  if (options.paused) return [];
+
+  const events: FishAteFoodEvent[] = [];
+  for (const fishEntity of sortedLivingHerbivores(world)) {
+    const foods = [...foodWithPosition(world)] as SimulationEntity[];
+    foods.sort(compareFoodEntitiesStableTieBreak);
+    const chosen = pickFoodToEat(fishEntity.position, foods, fishEntity.movementTargetPosition);
+    if (chosen === undefined) continue;
+
+    world.remove(chosen);
+    resetFishHungerAfterSuccessfulMeal(fishEntity.fish!);
+    delete fishEntity.movementTargetPosition;
+    events.push({ kind: "fish_ate_food", displayName: fishEntity.fish!.displayName });
+  }
+  return events;
+}

--- a/src/sim/targeting/nearestFoodTargeting.ts
+++ b/src/sim/targeting/nearestFoodTargeting.ts
@@ -13,7 +13,7 @@ function distanceSquared(a: Vec3, b: Vec3): number {
  * Deterministic ordering when two flakes are equally far: lexicographic `position`,
  * then `spawnedAtSimDays` (mirrors stable array / id tie-break intent in issue #11).
  */
-function compareFoodTieBreak(a: SimulationEntity, b: SimulationEntity): number {
+export function compareFoodEntitiesStableTieBreak(a: SimulationEntity, b: SimulationEntity): number {
   const pa = a.position;
   const pb = b.position;
   if (pa.x !== pb.x) return pa.x - pb.x;
@@ -29,7 +29,7 @@ function compareFoodTieBreak(a: SimulationEntity, b: SimulationEntity): number {
  */
 export function updateHerbivoreNearestFoodTargets(world: World<SimulationEntity>): void {
   const foods = [...foodWithPosition(world)] as SimulationEntity[];
-  foods.sort(compareFoodTieBreak);
+  foods.sort(compareFoodEntitiesStableTieBreak);
 
   for (const entity of fishWithKinematics(world)) {
     const e = entity as SimulationEntity;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -24,6 +24,12 @@ export type FishDiedStarvationEvent = {
   displayName: string;
 };
 
+/** Emitted once per flake successfully eaten (herbivore feed loop; toasts in a later issue). */
+export type FishAteFoodEvent = {
+  kind: "fish_ate_food";
+  displayName: string;
+};
+
 /** Toasts / UI: one entry per hunger milestone crossing in a single hunger step. */
 export type FishHungerMilestoneEvent =
   | FishBecameHungryEvent

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -3,8 +3,10 @@ import { useSimulationClock } from "../game/simulationClockContext";
 import { useSimulationWorld } from "../game/simulationWorldContext";
 import {
   clampWallDeltaSeconds,
+  dispatchFishAteFoodEvents,
   dispatchFishHungerMilestoneEvents,
   stepFishKinematicsWallDelta,
+  stepHerbivoreEatNearbyFood,
   stepHungerTimersWallDelta,
   updateHerbivoreNearestFoodTargets,
 } from "../sim";
@@ -22,6 +24,8 @@ export function SimulationFrameBridge() {
     const dt = clampWallDeltaSeconds(delta);
     updateHerbivoreNearestFoodTargets(world);
     stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
+    const eatEvents = stepHerbivoreEatNearbyFood(world, { paused });
+    dispatchFishAteFoodEvents(eatEvents);
     const hungerEvents = stepHungerTimersWallDelta(world, { wallDeltaSeconds: dt });
     dispatchFishHungerMilestoneEvents(hungerEvents);
     advanceByWallDelta(dt);


### PR DESCRIPTION
Closes #12

## Summary
- Adds `stepHerbivoreEatNearbyFood` (interaction phase): living herbivores within `HERBIVORE_FOOD_EAT_DISTANCE` consume one flake per step using movement-target preference then closest-in-range with stable food tie-break; removes the food entity, calls `resetFishHungerAfterSuccessfulMeal`, clears `movementTargetPosition`, returns one `fish_ate_food` event per flake.
- Wires `SimulationFrameBridge` after kinematics, before hunger timers (targeting → movement → interactions → vitals).
- `fishEatFoodEventBridge` mirrors hunger milestone dispatch for future toasts.
- Exports `compareFoodEntitiesStableTieBreak` from nearest-food targeting for shared deterministic ordering.

## Verification
`pnpm lint` — pass (eslint)

`pnpm test` — pass (18 files, 96 tests)

`pnpm build` — pass (`tsc -b && vite build`)

## Visual / interaction (Tier B)
Browser MCP unavailable—manual only.

Suggested manual check: `pnpm dev`, unpause, drop food so the starter herbivore can reach a flake; confirm flake disappears when the fish reaches it, fish continues without stuck targeting, pause still freezes the tank.

## Sub-agent return contract
1. **Worktree:** `/Users/michael/Documents/the-aquarium/.worktrees/issue-12-eat-food` — **Branch:** `issue-12-eat-food`
2. **Commit SHA:** `60a2040` (update if amended)
3. **PR:** (this PR)
4. **Commands:** see Verification above
5. **Blockers:** none (issue scope)