### PR TITLE
#13 Add health gain on eat when fish below max health

### DIFF
--- a/src/sim/interactions/eatConstants.ts
+++ b/src/sim/interactions/eatConstants.ts
@@ -1,0 +1,5 @@
+/**
+ * Herbivore flake meals: health recovery when damaged (`docs/the-game.md`).
+ * At max health, weight gain applies instead (separate issue).
+ */
+export const HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX = 1;

--- a/src/sim/interactions/herbivoreEatNearbyFood.test.ts
+++ b/src/sim/interactions/herbivoreEatNearbyFood.test.ts
@@ -44,6 +44,40 @@ describe("stepHerbivoreEatNearbyFood", () => {
     expect(fish.fish.hungerDays).toBe(0);
     expect(fish.fish.hungerStage).toBe("healthy");
     expect((fish as { movementTargetPosition?: unknown }).movementTargetPosition).toBeUndefined();
+    expect(fish.fish.health).toBe(3);
+  });
+
+  it("gains one health per successful eat when below max, capped at 3", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, {
+      ...herbivoreFish,
+      fish: {
+        ...herbivoreFish.fish,
+        health: 1,
+        hungerStage: "starving",
+        hungerDays: 3,
+      },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0, y: 0.35, z: 0 } });
+    stepHerbivoreEatNearbyFood(world, { paused: false });
+    expect(fish.fish.health).toBe(2);
+    expect(fish.fish.hungerDays).toBe(0);
+  });
+
+  it("at health 2, one eat reaches full health without exceeding 3", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, {
+      ...herbivoreFish,
+      fish: {
+        ...herbivoreFish.fish,
+        health: 2,
+        hungerStage: "hungry",
+        hungerDays: 2,
+      },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0, y: 0.35, z: 0 } });
+    stepHerbivoreEatNearbyFood(world, { paused: false });
+    expect(fish.fish.health).toBe(3);
   });
 
   it("fires eat dispatch exactly once per returned event", () => {

--- a/src/sim/interactions/herbivoreEatNearbyFood.ts
+++ b/src/sim/interactions/herbivoreEatNearbyFood.ts
@@ -1,7 +1,8 @@
 import type { World } from "miniplex";
 import { compareFoodEntitiesStableTieBreak } from "../targeting/nearestFoodTargeting";
 import { resetFishHungerAfterSuccessfulMeal } from "../hungerTimer";
-import type { FishAteFoodEvent, SimulationEntity, Vec3 } from "../types";
+import type { FishAteFoodEvent, FishState, SimulationEntity, Vec3 } from "../types";
+import { HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX } from "./eatConstants";
 import { fishWithKinematics, foodWithPosition } from "../world";
 
 /** World-space mouth reach: fish snaps up a flake when centers are within this distance. */
@@ -14,6 +15,13 @@ const eatDistanceSquared = HERBIVORE_FOOD_EAT_DISTANCE * HERBIVORE_FOOD_EAT_DIST
  * treats the flake as the intended target even after tiny kinematic drift.
  */
 const MOVEMENT_TARGET_MATCH_EPSILON_SQ = 1e-10;
+
+/** Once per successful flake eat; no-op at full health (weight path is separate). */
+function applyHealthGainAfterSuccessfulHerbivoreFoodMeal(fish: FishState): void {
+  if (!fish.alive || fish.health >= 3) return;
+  fish.health = (fish.health +
+    HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX) as FishState["health"];
+}
 
 function distanceSquared(a: Vec3, b: Vec3): number {
   const dx = a.x - b.x;
@@ -108,6 +116,7 @@ export function stepHerbivoreEatNearbyFood(
 
     world.remove(chosen);
     resetFishHungerAfterSuccessfulMeal(fishEntity.fish!);
+    applyHealthGainAfterSuccessfulHerbivoreFoodMeal(fishEntity.fish!);
     delete fishEntity.movementTargetPosition;
     events.push({ kind: "fish_ate_food", displayName: fishEntity.fish!.displayName });
   }


### PR DESCRIPTION
## Linked issue
Closes #13

## Summary
- Introduced `HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX` (1) in `src/sim/interactions/eatConstants.ts` per `docs/the-game.md`.
- After each successful herbivore flake eat, `stepHerbivoreEatNearbyFood` applies one health point when `health < 3`; at max health the fish is unchanged (weight on eat remains for #14).
- Runs once per successful eat, immediately after `resetFishHungerAfterSuccessfulMeal`.

## Definition of done
- [x] Health increases by configured amount.
- [x] Health does not exceed max.
- [x] Heal logic only applies below max health.

## Verification
```text
pnpm lint
# eslint . — exit 0

pnpm test
# Test Files  18 passed (18)
#      Tests  98 passed (98)

pnpm build
# tsc -b && vite build — exit 0
```

**Visual / interaction tier:** **C** (simulation-only; no UI or toasts in this PR).

## Sub-agent return contract
1. **Worktree:** `/Users/michael/Documents/the-aquarium/.worktrees/issue-13-heal-on-eat` — **branch:** `issue-13-heal-on-eat`
2. **Commit:** `1d16c3b`
3. **PR:** https://github.com/Michael-F-Bryan/the-aquarium/pull/172
4. **Commands:** as in Verification section above
5. **Blockers:** none