### PR TITLE
#14 Add weight gain on eat when fish at max health

### DIFF
--- a/src/sim/interactions/eatConstants.ts
+++ b/src/sim/interactions/eatConstants.ts
@@ -1,5 +1,8 @@
 /**
  * Herbivore flake meals: health recovery when damaged (`docs/the-game.md`).
- * At max health, weight gain applies instead (separate issue).
+ * At max health (3), each successful flake eat adds weight instead of health.
  */
 export const HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX = 1;
+
+/** Grams added per successful flake eat when the herbivore is already at full health (`docs/the-game.md`). */
+export const WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH = 100;

--- a/src/sim/interactions/herbivoreEatNearbyFood.test.ts
+++ b/src/sim/interactions/herbivoreEatNearbyFood.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSimulationWorld, registerFish, registerFood } from "../world";
 import { dispatchFishAteFoodEvents, subscribeFishAteFoodEvents } from "../fishEatFoodEventBridge";
+import { WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH } from "./eatConstants";
 import { HERBIVORE_FOOD_EAT_DISTANCE, stepHerbivoreEatNearbyFood } from "./herbivoreEatNearbyFood";
 
 const herbivoreFish = {
@@ -45,6 +46,19 @@ describe("stepHerbivoreEatNearbyFood", () => {
     expect(fish.fish.hungerStage).toBe("healthy");
     expect((fish as { movementTargetPosition?: unknown }).movementTargetPosition).toBeUndefined();
     expect(fish.fish.health).toBe(3);
+    expect(fish.fish.weightGrams).toBe(100 + WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH);
+  });
+
+  it("at max health, adds configured weight grams and does not change health", () => {
+    const world = createSimulationWorld();
+    const fish = registerFish(world, {
+      ...herbivoreFish,
+      fish: { ...herbivoreFish.fish, weightGrams: 250 },
+    });
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: 0, y: 0.35, z: 0 } });
+    stepHerbivoreEatNearbyFood(world, { paused: false });
+    expect(fish.fish.health).toBe(3);
+    expect(fish.fish.weightGrams).toBe(250 + WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH);
   });
 
   it("gains one health per successful eat when below max, capped at 3", () => {
@@ -62,6 +76,7 @@ describe("stepHerbivoreEatNearbyFood", () => {
     stepHerbivoreEatNearbyFood(world, { paused: false });
     expect(fish.fish.health).toBe(2);
     expect(fish.fish.hungerDays).toBe(0);
+    expect(fish.fish.weightGrams).toBe(100);
   });
 
   it("at health 2, one eat reaches full health without exceeding 3", () => {

--- a/src/sim/interactions/herbivoreEatNearbyFood.ts
+++ b/src/sim/interactions/herbivoreEatNearbyFood.ts
@@ -2,7 +2,10 @@ import type { World } from "miniplex";
 import { compareFoodEntitiesStableTieBreak } from "../targeting/nearestFoodTargeting";
 import { resetFishHungerAfterSuccessfulMeal } from "../hungerTimer";
 import type { FishAteFoodEvent, FishState, SimulationEntity, Vec3 } from "../types";
-import { HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX } from "./eatConstants";
+import {
+  HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX,
+  WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH,
+} from "./eatConstants";
 import { fishWithKinematics, foodWithPosition } from "../world";
 
 /** World-space mouth reach: fish snaps up a flake when centers are within this distance. */
@@ -16,9 +19,13 @@ const eatDistanceSquared = HERBIVORE_FOOD_EAT_DISTANCE * HERBIVORE_FOOD_EAT_DIST
  */
 const MOVEMENT_TARGET_MATCH_EPSILON_SQ = 1e-10;
 
-/** Once per successful flake eat; no-op at full health (weight path is separate). */
-function applyHealthGainAfterSuccessfulHerbivoreFoodMeal(fish: FishState): void {
-  if (!fish.alive || fish.health >= 3) return;
+/** Once per successful flake eat: weight at full health, else health recovery (mutually exclusive). */
+function applyHerbivoreFlakeMealOutcomes(fish: FishState): void {
+  if (!fish.alive) return;
+  if (fish.health === 3) {
+    fish.weightGrams += WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH;
+    return;
+  }
   fish.health = (fish.health +
     HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX) as FishState["health"];
 }
@@ -116,7 +123,7 @@ export function stepHerbivoreEatNearbyFood(
 
     world.remove(chosen);
     resetFishHungerAfterSuccessfulMeal(fishEntity.fish!);
-    applyHealthGainAfterSuccessfulHerbivoreFoodMeal(fishEntity.fish!);
+    applyHerbivoreFlakeMealOutcomes(fishEntity.fish!);
     delete fishEntity.movementTargetPosition;
     events.push({ kind: "fish_ate_food", displayName: fishEntity.fish!.displayName });
   }


### PR DESCRIPTION
Closes #14

## Summary

- Herbivore flake meals at **full health (3)** add `WEIGHT_GRAMS_GAIN_PER_SUCCESSFUL_FOOD_EAT_AT_MAX_HEALTH` (100g per `docs/the-game.md`) to `weightGrams`; health is unchanged.
- Below max health, behavior stays as in #13: only health increases by `HEALTH_GAIN_PER_SUCCESSFUL_FOOD_EAT_WHEN_BELOW_MAX`; weight is unchanged. The two paths are mutually exclusive.

## Verification

**Tier C** (simulation-only; no UI/3D/input changes).

### `pnpm exec vitest run src/sim/interactions/herbivoreEatNearbyFood.test.ts`

```
 RUN  v4.1.5

 ✓ src/sim/interactions/herbivoreEatNearbyFood.test.ts (12 tests) 7ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

### `pnpm lint`

```
> the-aquarium@0.0.0 lint
> eslint .
```

(exit 0)

### `pnpm test`

```
 Test Files  18 passed (18)
      Tests  99 passed (99)
```

### `pnpm build`

```
✓ built in 255ms
```

(exit 0)

## Sub-agent return contract

1. **Worktree:** `/Users/michael/Documents/the-aquarium/.worktrees/issue-14-weight-on-eat` — **branch:** `issue-14-weight-on-eat`
2. **Commit:** `3b73c973b7a7982895a4d54f4d2a355c22c7ad93`
3. **PR:** https://github.com/Michael-F-Bryan/the-aquarium/pull/174
4. **Verification:** see above
5. **Blockers:** none