### PR TITLE
#173 Render food flakes in the tank from ECS state

### DIFF
--- a/src/tank/FoodMeshesFromWorld.tsx
+++ b/src/tank/FoodMeshesFromWorld.tsx
@@ -1,0 +1,62 @@
+import { useLayoutEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import type { InstancedMesh } from "three";
+import { MeshStandardMaterial, Object3D, SphereGeometry } from "three";
+import { useSimulationWorld } from "../game/simulationWorldContext";
+import type { SimulationEntity } from "../sim/types";
+import { foodWithPosition } from "../sim/world";
+
+/** Upper bound on concurrent flakes (instancing); drop rules keep this comfortably small. */
+const MAX_FOOD_INSTANCES = 128;
+
+const dummy = new Object3D();
+
+/**
+ * Renders food flakes from ECS positions. Updates instance transforms each frame; no
+ * simulation writes from R3F. Raycast is a no-op so picks still hit `TankDropFoodSurface`.
+ */
+export function FoodMeshesFromWorld() {
+  const { world } = useSimulationWorld();
+  const meshRef = useRef<InstancedMesh>(null);
+
+  const [geometry, material] = useMemo(() => {
+    const geom = new SphereGeometry(0.048, 12, 10);
+    const mat = new MeshStandardMaterial({
+      color: "#c4a060",
+      roughness: 0.7,
+      metalness: 0.06,
+    });
+    return [geom, mat] as const;
+  }, []);
+
+  useLayoutEffect(() => {
+    const mesh = meshRef.current;
+    if (mesh) mesh.count = 0;
+  }, []);
+
+  useFrame(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    const foods = [...foodWithPosition(world)] as SimulationEntity[];
+    const n = Math.min(foods.length, MAX_FOOD_INSTANCES);
+    mesh.count = n;
+    for (let i = 0; i < n; i++) {
+      const p = foods[i].position;
+      dummy.position.set(p.x, p.y, p.z);
+      dummy.rotation.set(0, 0, 0);
+      dummy.scale.set(1.35, 0.28, 1.05);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[geometry, material, MAX_FOOD_INSTANCES]}
+      frustumCulled={false}
+      raycast={() => {}}
+    />
+  );
+}

--- a/src/tank/TankScene.tsx
+++ b/src/tank/TankScene.tsx
@@ -9,6 +9,7 @@ import {
   TANK_SCENE_BACKGROUND,
 } from "./tankCameraConstants";
 import { FishMeshesFromWorld } from "./FishMeshesFromWorld";
+import { FoodMeshesFromWorld } from "./FoodMeshesFromWorld";
 import { SimulationFrameBridge } from "./SimulationFrameBridge";
 import { TankDropFoodSurface } from "./TankDropFoodSurface";
 
@@ -41,6 +42,7 @@ export function TankScene({ className, paused = false }: TankSceneProps) {
       >
         <SimulationFrameBridge />
         <TankDropFoodSurface />
+        <FoodMeshesFromWorld />
         <FishMeshesFromWorld />
         <ambientLight intensity={0.55} />
         <directionalLight position={[4, 6, 3]} intensity={0.85} />


### PR DESCRIPTION
## Linked issue

Closes #173

## Summary

- Add `FoodMeshesFromWorld`: reads `foodWithPosition(world)` each frame via `useSimulationWorld` + `useFrame`, updates an `InstancedMesh` (up to 128 flakes). No simulation writes from R3F.
- Flattened golden-tan flake look (`meshStandardMaterial`, scaled sphere) aligned with `docs/the-game.md` flake feeding language.
- `raycast={() => {}}` on the instanced mesh so pointer picks still hit `TankDropFoodSurface` only.
- Mount from `TankScene` after the drop surface, before fish meshes.

## Verification

### Commands (real output)

```
pnpm lint   # eslint . — clean
pnpm test   # vitest run — 18 files, 99 tests passed
pnpm build  # tsc -b && vite build — success
```

### Visual / interaction (Tier **B**)

Cursor IDE Browser MCP is not enabled for this workspace — **manual only.**

Checklist (run `pnpm dev`):

1. Drop a flake: tan/gold flattened sphere appears near the clamped hit position and tracks sim position each frame.
2. After the fish eats it (or expiry), the flake mesh is gone on the next frame.
3. Drops still register (invisible plane still receives clicks; flakes do not block drops).

## Sub-agent return contract

1. **Worktree:** `/Users/michael/Documents/the-aquarium/.worktrees/issue-173-food-meshes`
2. **Branch:** `issue-173-food-meshes`
3. **Commit:** `75e2ab8`
4. **PR:** https://github.com/Michael-F-Bryan/the-aquarium/pull/175
5. **Blockers:** none