### PR TITLE
#165 Review app chrome, HUD layout, and sprites/icons

### DIFF
--- a/docs/reviews/issue-165-app-chrome-hud-sprites-review.md
+++ b/docs/reviews/issue-165-app-chrome-hud-sprites-review.md
@@ -1,0 +1,83 @@
+# Issue #165 Review: App Chrome, HUD, and Sprites/Icons
+
+## Scope and method
+
+- Issue: `#165`
+- Review mode: **Tier B** (**Browser MCP unavailable—manual only.**)
+- Environment: `pnpm dev` on local worktree branch `issue-165-ui-review`
+- Evidence sources:
+  - Runtime startup and local shell/manual notes
+  - Source review of `src/App.tsx`, `src/tank/TankScene.tsx`, `src/tank/FishMeshesFromWorld.tsx`, `src/tank/FoodMeshesFromWorld.tsx`, and HUD shell components
+
+## Desktop and narrow-width notes
+
+- **Desktop width note:** Current shell presents a single full-screen tank surface with a compact top-right HUD stack. The documented four-region layout from `README.md` (header, left sidebar, center canvas, right sidebar) is not yet represented in the shipped shell.
+- **Narrow width note:** Because the shell currently uses one overlay cluster and no dedicated sidebars, responsive behavior avoids grid breakage for now, but does not meet intended information hierarchy for playable-seed chrome.
+- **Canvas sizing risk note:** The report that canvas can appear around ~150px tall is plausible with the current structure because the shell relies on `min-h-dvh` rather than an explicit fixed-height viewport contract, while the `Canvas` itself depends on parent height (`h-full`).
+
+## Evaluation against criteria
+
+1. **Viewport and canvas dominance** - **Should**
+   - Tank is visually dominant today, but sizing contract is fragile and can collapse if parent height is not explicit.
+2. **Chrome layout vs. product intent** - **Blocker**
+   - `README.md` describes header + two sidebars + center canvas; current UI is an overlay stack instead.
+3. **Information hierarchy** - **Should**
+   - Day and score are present, but biomass and structured status surfaces are absent in chrome.
+4. **Simulation readability** - **Should**
+   - Tank remains readable in current minimalist shell, but no structural containment keeps overlays from competing with playfield as HUD grows.
+5. **Interaction clarity** - **Should**
+   - Pause button and paused status are clear; pointer routing for feed clicks is intentionally isolated (`TankDropFoodSurface`) and consistent with architecture guidance.
+6. **Responsive / resize behavior** - **Should**
+   - Current simple layout avoids obvious grid collapse but does not satisfy intended regioned composition, especially for future lists/panels.
+7. **Consistency with stack decisions** - **Should**
+   - Tailwind and pointer capture boundaries are aligned with `docs/implementation-decisions.md`, but product-intent layout in `README.md` is not yet reflected.
+8. **Accessibility baseline** - **Should**
+   - Existing status surfaces use `role=status`/`aria-live`; event log uses `role=log`. Keyboard pause path (`Escape`) should be validated and documented with the full pause modal flow.
+9. **Sprites and icons** - **Blocker** (for playable-seed feel)
+   - Fish and food are placeholder primitives (sphere meshes with flat materials), and HUD controls are text-only with no consistent icon language. This is functionally valid but visually below playable-seed goals.
+
+## Prioritized recommendations
+
+### Blockers
+
+- **B1 - Fix canvas sizing contract and viewport ownership**
+  - Define explicit viewport height ownership for shell/canvas region.
+  - Ensure no path leaves R3F canvas without a concrete parent height.
+- **B2 - Introduce playable-seed sprite/icon baseline**
+  - Replace primitive fish/food stand-ins with consistent readable sprite forms (or equivalent mesh language) and define a minimal icon set for HUD controls.
+
+### Should
+
+- **S1 - Implement documented chrome regions**
+  - Add header + left summary rail + central canvas + right fish/status rail matching `README.md` intent.
+- **S2 - Harden responsive behavior**
+  - Define desktop vs. narrow breakpoints, panel collapse/stack rules, and explicit scroll ownership.
+- **S3 - Formalize interaction/accessibility checks**
+  - Validate pause keyboard path, focus movement for overlays/modals, and toast/live-region behavior under rapid events.
+
+### Nice
+
+- **N1 - Add lightweight UI asset/style guide**
+  - Document sprite/icon source-of-truth, scale/export rules, and naming so follow-on tickets avoid style drift.
+
+## Keep vs change
+
+- **Keep**
+  - Simulation-authoritative render boundary and pointer routing approach.
+  - Existing live-region semantics in shell placeholders.
+- **Change**
+  - Shell structure to match intended four-region chrome.
+  - Canvas height contract to eliminate fixed-height regressions.
+  - Placeholder sprite/icon presentation to reach playable-seed visual clarity.
+
+## Backlog tracking
+
+All follow-ups were created under milestone **Release 0 - Playable Seed**:
+
+- **Blocker**
+  - `#176` - Canvas sizing contract for full-viewport tank stage
+  - `#178` - Ship playable-seed sprite pass for fish, food, and tank floor
+- **Should**
+  - `#177` - Implement README-aligned chrome layout and responsive panel rules
+- **Nice**
+  - `#179` - Standardize HUD icon set and asset export rules


### PR DESCRIPTION
## Summary
- Add a durable review artifact at `docs/reviews/issue-165-app-chrome-hud-sprites-review.md` covering app chrome, HUD hierarchy, canvas sizing risk, and sprite/icon quality versus playable-seed goals.
- Classify recommendations by blocker/should/nice and keep this PR scoped to review/planning (no implementation fixes).
- Create and link milestone-scoped follow-up issues: #176, #177, #178, #179, and post them back on #165.

## Linked issue
- Closes #165

## Visual / interaction verification
- **Tier B**: **Browser MCP unavailable—manual only.**
- Ran `pnpm dev` in this worktree (`http://localhost:5176/`) and captured review notes in the artifact.
- Checked shell/pointer architecture in code paths used for pause and tank interaction (`App.tsx`, `TankScene.tsx`, `TankDropFoodSurface.tsx`).

## Backlog follow-ups (Release 0 - Playable Seed)
- **Blocker**: #176 Canvas sizing contract for full-viewport tank stage
- **Blocker**: #178 Ship playable-seed sprite pass for fish, food, and tank floor
- **Should**: #177 Implement README-aligned chrome layout and responsive panel rules
- **Nice**: #179 Standardize HUD icon set and asset export rules

## Verification
### `pnpm lint`
```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-165-ui-review
> eslint .
```

### `pnpm test`
```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-165-ui-review
> vitest run

 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-165-ui-review

 Test Files  18 passed (18)
      Tests  99 passed (99)
   Start at  23:44:44
   Duration  4.41s (transform 1.17s, setup 708ms, import 2.51s, tests 935ms, environment 25.90s)
```

### `pnpm build`
```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-165-ui-review
> tsc -b && vite build

vite v8.0.10 building client environment for production...
transforming...✓ 68 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.30 kB
dist/assets/index-C8ATQl1m.css     14.60 kB │ gzip:   3.52 kB
dist/assets/index-CWMdAF-L.js   1,103.89 kB │ gzip: 303.33 kB

✓ built in 305ms
[plugin builtin:vite-reporter]
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```