### PR TITLE
#23 Run Release 0 bug bash checklist and log defects

### DIFF
--- a/docs/qa/release-0-bug-bash-checklist.md
+++ b/docs/qa/release-0-bug-bash-checklist.md
@@ -1,0 +1,35 @@
+# Release 0 Bug Bash Checklist
+
+Issue: #23  
+Milestone: Release 0 - Playable Seed  
+Date: 2026-05-03
+
+## Verification Tier
+
+- Tier B
+- Browser MCP unavailable - manual only.
+
+## Focused Checklist
+
+- [x] Confirm release scope and dependencies for #23.
+- [x] Start app with `pnpm dev` and confirm dev server readiness.
+- [x] Validate baseline behavior with automated checks (`pnpm test`).
+- [x] Review core Release 0 gameplay paths (feed, hunger/death, pause, save) via targeted code-path inspection and existing test coverage.
+- [x] Log material defects with severity, reproducible steps, and milestone assignment.
+- [x] Classify each defect as blocker or non-blocker.
+
+## Defects Logged
+
+1. #180 - Food flakes never expire after lifetime  
+   - Severity: High
+   - Classification: Non-blocker
+2. #181 - Escape key does not toggle pause  
+   - Severity: Medium
+   - Classification: Non-blocker
+3. #183 - Run snapshot autosave is not tied to simulated day rollover  
+   - Severity: High
+   - Classification: Non-blocker
+
+## Blocker Summary
+
+- No release blockers identified in this bug bash pass.


### PR DESCRIPTION
## Summary
- Add `docs/qa/release-0-bug-bash-checklist.md` with a completed Release 0 bug-bash checklist and blocker classification summary.
- Execute a focused Release 0 bug bash pass and log material defects as milestone-scoped issues: #180, #181, and #183.
- Comment on issue #23 with findings and links to the logged defects.

## Defects logged
- #180 — Food flakes never expire after lifetime (High, non-blocker)
- #181 — Escape key does not toggle pause (Medium, non-blocker)
- #183 — Run snapshot autosave is not tied to simulated day rollover (High, non-blocker)

## Visual / interaction verification tier
- **Tier B**: Browser MCP unavailable - manual only.
- `pnpm dev` started successfully in this worktree and served at `http://localhost:5177/`.

## Verification outputs
### `pnpm lint`
```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-23-bug-bash
> eslint .
```

### `pnpm test`
```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-23-bug-bash
> vitest run

 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-23-bug-bash

 Test Files  18 passed (18)
      Tests  99 passed (99)
   Start at  23:46:31
   Duration  2.65s (transform 1.05s, setup 739ms, import 1.69s, tests 560ms, environment 14.83s)
```

### `pnpm build`
```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-23-bug-bash
> tsc -b && vite build

vite v8.0.10 building client environment for production...
transforming...✓ 68 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.31 kB
dist/assets/index-CUh0QDYJ.css     14.54 kB │ gzip:   3.49 kB
dist/assets/index-BxHToTUI.js   1,103.89 kB │ gzip: 303.33 kB

✓ built in 269ms
[plugin builtin:vite-reporter]
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```

## Linked issue
- Closes #23