### PR TITLE
#176 Canvas sizing contract for full-viewport tank stage

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,6 +18,18 @@ describe("App shell", () => {
     expect(container.querySelector("canvas")).toBeTruthy();
   });
 
+  it("enforces full-viewport sizing contract for the tank stage", () => {
+    const { container } = render(<App />);
+    const shellRoot = container.firstElementChild;
+    const tankSceneRoot = screen.getByTestId("tank-scene-root");
+
+    expect(shellRoot).toBeTruthy();
+    expect(shellRoot?.className).toContain("h-dvh");
+    expect(shellRoot?.className).not.toContain("min-h-dvh");
+    expect(tankSceneRoot.className).toContain("h-full");
+    expect(tankSceneRoot.className).toContain("min-h-0");
+  });
+
   it("shows the simulation day counter in the HUD", () => {
     render(<App />);
     expect(screen.getByRole("status", { name: /current simulation day,\s*1/i })).toBeTruthy();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { ToastLogShell } from "./ui/ToastLogShell";
 function GameShell() {
   const { paused, togglePause } = useSimulationClock();
   return (
-    <div className="relative flex min-h-dvh flex-col">
+    <div className="relative flex h-dvh w-full flex-col overflow-hidden">
       <div className="pointer-events-auto absolute top-4 right-4 z-20 flex flex-col items-end gap-2">
         <DayCounter />
         <ScorePlaceholder />
@@ -36,7 +36,7 @@ function GameShell() {
           </div>
         ) : null}
       </div>
-      <TankScene className="min-h-dvh w-full flex-1" paused={paused} />
+      <TankScene className="h-full min-h-0 w-full flex-1" paused={paused} />
       <p className="pointer-events-none absolute bottom-6 left-1/2 -translate-x-1/2 text-sm text-neutral-400 drop-shadow-sm">
         The Aquarium
       </p>


### PR DESCRIPTION
Closes #176

## Summary
- add a regression test in `src/App.test.tsx` that codifies viewport height ownership for the shell and tank scene root
- switch `GameShell` from `min-h-dvh` inheritance to explicit viewport ownership (`h-dvh w-full overflow-hidden`)
- give the tank stage explicit non-collapsing sizing (`h-full min-h-0 flex-1`) so the R3F canvas cannot fall back to intrinsic height

## Verification
### `pnpm lint`
```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-176-canvas-sizing
> eslint .
```

### `pnpm test`
```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-176-canvas-sizing
> vitest run

 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-176-canvas-sizing

 Test Files  18 passed (18)
      Tests  100 passed (100)
   Start at  23:55:35
   Duration  3.19s (transform 1.77s, setup 676ms, import 2.84s, tests 634ms, environment 17.81s)
```

### `pnpm build`
```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-176-canvas-sizing
> tsc -b && vite build

vite v8.0.10 building client environment for production...
transforming...✓ 68 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.31 kB
dist/assets/index-DBW-I7j3.css     14.70 kB │ gzip:   3.54 kB
dist/assets/index-DdOc9SEH.js   1,103.91 kB │ gzip: 303.34 kB

[plugin builtin:vite-reporter]
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 267ms
```

## Visual verification (Tier B)
Browser MCP unavailable—manual only.

Manual rerun evidence:
- launched `pnpm dev --host 127.0.0.1 --port 4174`
- Vite reported ready at `http://127.0.0.1:4174/`

Checklist (pass/fail):
- [ ] initial render observed — FAIL (not visually observed in a browser session from this environment)
- [ ] primary interaction completed (click-to-feed) — FAIL (not executed)
- [ ] control interaction completed (pause/resume) — FAIL (not executed)
- [ ] resize check completed (desktop + narrow width) — FAIL (not executed)

### What remains
A manual browser pass is still required to satisfy Tier B interaction evidence. Execute the four interactions above and then update these checklist entries to pass/fail based on observed behavior.