### PR TITLE
#179 Standardize HUD icon set and export rules

### DIFF
--- a/docs/hud-icon-style-guide.md
+++ b/docs/hud-icon-style-guide.md
@@ -1,0 +1,33 @@
+# HUD Icon Baseline (Playable Seed)
+
+This baseline keeps HUD/chrome icons visually consistent while the playable-seed UI is still lightweight.
+
+## Source Strategy
+
+- Use in-repo inline SVG React components (`src/ui/hudIcons.tsx`) for current controls.
+- Avoid external icon packages in playable seed unless we need a larger icon surface.
+- Export all new icons through the shared module so controls do not invent one-off SVG styles.
+
+## Visual Rules
+
+- Artboard: `24x24`.
+- Display size: `16x16` (`h-4 w-4`) inside HUD controls.
+- Stroke: `1.75`, round caps, round joins.
+- Fill: `none` by default for control/status glyphs.
+- Color: inherit text color (`currentColor`), using neutral HUD contrast (`text-neutral-300` on dark chrome).
+- Spacing: icon + text use inline row with `gap-2`.
+
+## Usage Rules
+
+- Keep text labels; icons assist recognition and should not replace readable labels.
+- Set decorative HUD icons to `aria-hidden="true"` and keep accessible naming on the parent control.
+- Reuse the shared icon module for top-level controls (`Day`, `Score`, `Event log`, `Pause/Resume`).
+
+## Export / Review Checklist
+
+- [ ] Icon authored on `24x24` viewBox.
+- [ ] Stroke-only path at `1.75` with round caps/joins.
+- [ ] Rendered at `16x16` in HUD.
+- [ ] Uses `currentColor` and passes dark-background contrast.
+- [ ] Added to `src/ui/hudIcons.tsx` (no ad-hoc inline SVG in feature files).
+- [ ] Parent control keeps an explicit accessible label.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useSimulationClock } from "./game/simulationClockContext";
 import { loadRunBootstrapFromLocalStorage } from "./persistence/runSnapshotStorage";
 import { TankScene } from "./tank/TankScene";
 import { DayCounter } from "./ui/DayCounter";
+import { PauseIcon, PlayIcon } from "./ui/hudIcons";
 import { ScorePlaceholder } from "./ui/ScorePlaceholder";
 import { ToastLogShell } from "./ui/ToastLogShell";
 
@@ -33,11 +34,16 @@ function GameShell() {
         <ToastLogShell entries={[]} />
         <button
           type="button"
-          className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium text-neutral-100 shadow-sm backdrop-blur-sm hover:bg-neutral-800"
+          className="inline-flex items-center gap-2 rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium text-neutral-100 shadow-sm backdrop-blur-sm hover:bg-neutral-800"
           aria-pressed={paused}
           onClick={togglePause}
         >
-          {paused ? "Resume simulation" : "Pause simulation"}
+          {paused ? (
+            <PlayIcon className="h-4 w-4 shrink-0 text-neutral-300" />
+          ) : (
+            <PauseIcon className="h-4 w-4 shrink-0 text-neutral-300" />
+          )}
+          <span>{paused ? "Resume simulation" : "Pause simulation"}</span>
         </button>
         {paused ? (
           <div

--- a/src/ui/DayCounter.tsx
+++ b/src/ui/DayCounter.tsx
@@ -1,4 +1,5 @@
 import { useSimulationClock } from "../game/simulationClockContext";
+import { CalendarIcon } from "./hudIcons";
 
 function calendarDayFromSimDays(simDays: number): number {
   // Guard against float dust (e.g. 26 × 0.25/6.5) landing just below the next integer.
@@ -15,7 +16,10 @@ export function DayCounter() {
       aria-label={`Current simulation day, ${day}`}
       className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium tabular-nums tracking-wide text-neutral-100 shadow-sm backdrop-blur-sm"
     >
-      Day {day}
+      <span className="inline-flex items-center gap-2">
+        <CalendarIcon className="h-4 w-4 shrink-0 text-neutral-300" />
+        <span>Day {day}</span>
+      </span>
     </div>
   );
 }

--- a/src/ui/ScorePlaceholder.tsx
+++ b/src/ui/ScorePlaceholder.tsx
@@ -1,3 +1,5 @@
+import { BadgeIcon } from "./hudIcons";
+
 /**
  * HUD slot for score. Displays static placeholder text until scoring ships in a later release.
  */
@@ -9,7 +11,10 @@ export function ScorePlaceholder() {
       aria-label="Score placeholder"
       className="rounded-md border border-neutral-600 bg-neutral-900/90 px-3 py-1.5 text-sm font-medium tabular-nums tracking-wide text-neutral-100 shadow-sm backdrop-blur-sm"
     >
-      <span className="text-neutral-300">Score</span>
+      <span className="inline-flex items-center gap-2">
+        <BadgeIcon className="h-4 w-4 shrink-0 text-neutral-300" />
+        <span className="text-neutral-300">Score</span>
+      </span>
       <span className="ml-2 font-semibold text-neutral-100">—</span>
     </div>
   );

--- a/src/ui/ToastLogShell.tsx
+++ b/src/ui/ToastLogShell.tsx
@@ -1,3 +1,5 @@
+import { ListIcon } from "./hudIcons";
+
 export type ToastLogEntry = {
   id: string;
   message: string;
@@ -14,6 +16,12 @@ type ToastLogShellProps = {
 export function ToastLogShell({ entries }: ToastLogShellProps) {
   return (
     <div className="w-full max-w-xs rounded-md border border-neutral-600 bg-neutral-900/90 shadow-sm backdrop-blur-sm">
+      <div className="border-b border-neutral-600/80 px-3 py-2 text-xs font-semibold tracking-wide text-neutral-200">
+        <span className="inline-flex items-center gap-2">
+          <ListIcon className="h-4 w-4 shrink-0 text-neutral-300" />
+          <span>Event log</span>
+        </span>
+      </div>
       <div
         role="log"
         aria-label="Event log"

--- a/src/ui/hudIcons.tsx
+++ b/src/ui/hudIcons.tsx
@@ -1,0 +1,63 @@
+import type { SVGProps } from "react";
+
+type HudIconProps = Omit<SVGProps<SVGSVGElement>, "viewBox" | "fill" | "stroke">;
+
+function HudIconBase({ children, className = "h-4 w-4 shrink-0", ...rest }: HudIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function CalendarIcon(props: HudIconProps) {
+  return (
+    <HudIconBase {...props}>
+      <rect x="3.75" y="5.5" width="16.5" height="14.75" rx="2.25" />
+      <path d="M7.5 3.75v3.5M16.5 3.75v3.5M3.75 10h16.5" />
+    </HudIconBase>
+  );
+}
+
+export function BadgeIcon(props: HudIconProps) {
+  return (
+    <HudIconBase {...props}>
+      <path d="M12 3.75l2.55 5.166 5.7.828-4.125 4.02.975 5.678L12 16.75l-5.1 2.692.975-5.678-4.125-4.02 5.7-.828L12 3.75z" />
+    </HudIconBase>
+  );
+}
+
+export function ListIcon(props: HudIconProps) {
+  return (
+    <HudIconBase {...props}>
+      <path d="M5.25 7.5h2.25M9.75 7.5h9M5.25 12h2.25M9.75 12h9M5.25 16.5h2.25M9.75 16.5h9" />
+    </HudIconBase>
+  );
+}
+
+export function PauseIcon(props: HudIconProps) {
+  return (
+    <HudIconBase {...props}>
+      <rect x="5.5" y="4.5" width="4.5" height="15" rx="1" />
+      <rect x="14" y="4.5" width="4.5" height="15" rx="1" />
+    </HudIconBase>
+  );
+}
+
+export function PlayIcon(props: HudIconProps) {
+  return (
+    <HudIconBase {...props}>
+      <path d="M8.25 5.5l9.5 6.5-9.5 6.5V5.5z" />
+    </HudIconBase>
+  );
+}


### PR DESCRIPTION
## Linked issue
Closes #179

## Summary
- Add a shared inline SVG HUD icon module at `src/ui/hudIcons.tsx` with a consistent 24x24 stroke-only baseline.
- Apply baseline icons to existing top-level HUD controls: `DayCounter`, `ScorePlaceholder`, `ToastLogShell`, and the pause/resume control in `App`.
- Commit an in-repo style guide/checklist at `docs/hud-icon-style-guide.md` covering source strategy, size/stroke/fill/contrast, and export usage rules.

## Verification outputs
### `pnpm lint`
```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-179-hud-icons
> eslint .
```

### `pnpm test`
```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-179-hud-icons
> vitest run

RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-179-hud-icons
Test Files  18 passed (18)
Tests  101 passed (101)
Duration  2.73s
```

### `pnpm build`
```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-179-hud-icons
> tsc -b && vite build

vite v8.0.10 building client environment for production...
✓ 69 modules transformed.
✓ built in 418ms
```

## Visual / interaction verification
Tier: **B** (Browser MCP unavailable—manual only)

- Tested URL: `http://127.0.0.1:4173/`
- Viewports targeted: `1200x800`, `375x667`

Checklist:
- [ ] initial render observed — **FAIL** (no interactive browser session available to observe)
- [ ] primary interaction completed (pause/resume button click) — **FAIL** (no interactive browser session available to perform)
- [ ] control interaction completed (Escape pause toggle) — **FAIL** (no interactive browser session available to perform)
- [ ] resize check completed (desktop + narrow width) — **FAIL** (no interactive browser session available to perform)

Notes:
- Dev server started successfully at `http://127.0.0.1:4173/` during verification.
- Automated interaction coverage still passes in test suite (`App.test.tsx` includes pause/resume and Escape toggle assertions), but this does not replace Tier A/B visual interaction evidence.