### PR TITLE
#180 Expire food flakes after half-day lifetime

### DIFF
--- a/src/sim/foodExpiry.test.ts
+++ b/src/sim/foodExpiry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { foodWithPosition, createSimulationWorld, registerFood } from "./world";
+import { DEFAULT_FOOD_LIFETIME_SIM_DAYS, stepExpireFoodByAge } from "./foodExpiry";
+
+describe("stepExpireFoodByAge", () => {
+  it("removes flakes once their age reaches the default lifetime", () => {
+    const world = createSimulationWorld();
+    registerFood(world, { food: { spawnedAtSimDays: 1 }, position: { x: 0, y: 0.35, z: 0 } });
+
+    const removed = stepExpireFoodByAge(world, { simDays: 1 + DEFAULT_FOOD_LIFETIME_SIM_DAYS });
+
+    expect(removed).toBe(1);
+    expect([...foodWithPosition(world)]).toHaveLength(0);
+  });
+
+  it("keeps flakes younger than the default lifetime", () => {
+    const world = createSimulationWorld();
+    registerFood(world, { food: { spawnedAtSimDays: 4 }, position: { x: 0, y: 0.35, z: 0 } });
+
+    const removed = stepExpireFoodByAge(world, { simDays: 4 + DEFAULT_FOOD_LIFETIME_SIM_DAYS - 1e-9 });
+
+    expect(removed).toBe(0);
+    expect([...foodWithPosition(world)]).toHaveLength(1);
+  });
+
+  it("removes only expired flakes and leaves newer ones", () => {
+    const world = createSimulationWorld();
+    registerFood(world, { food: { spawnedAtSimDays: 0 }, position: { x: -0.2, y: 0.35, z: 0 } });
+    registerFood(world, { food: { spawnedAtSimDays: 2 }, position: { x: 0.2, y: 0.35, z: 0 } });
+
+    const removed = stepExpireFoodByAge(world, { simDays: 2.2 });
+
+    expect(removed).toBe(1);
+    const remaining = [...foodWithPosition(world)];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.food.spawnedAtSimDays).toBe(2);
+  });
+});

--- a/src/sim/foodExpiry.ts
+++ b/src/sim/foodExpiry.ts
@@ -1,0 +1,24 @@
+import type { World } from "miniplex";
+import { foodWithPosition } from "./world";
+import type { SimulationEntity } from "./types";
+
+/** Default flake lifetime from `docs/the-game.md`: half a simulated day. */
+export const DEFAULT_FOOD_LIFETIME_SIM_DAYS = 0.5;
+
+/**
+ * Removes food flakes whose age has reached the configured lifetime.
+ * Returns the number of flakes removed during this simulation step.
+ */
+export function stepExpireFoodByAge(
+  world: World<SimulationEntity>,
+  options: { simDays: number; lifetimeSimDays?: number },
+): number {
+  const lifetimeSimDays = options.lifetimeSimDays ?? DEFAULT_FOOD_LIFETIME_SIM_DAYS;
+  let removed = 0;
+  for (const entity of foodWithPosition(world)) {
+    if (options.simDays - entity.food.spawnedAtSimDays < lifetimeSimDays) continue;
+    world.remove(entity);
+    removed += 1;
+  }
+  return removed;
+}

--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -54,6 +54,7 @@ export {
   HERBIVORE_FOOD_EAT_DISTANCE,
   stepHerbivoreEatNearbyFood,
 } from "./interactions/herbivoreEatNearbyFood";
+export { DEFAULT_FOOD_LIFETIME_SIM_DAYS, stepExpireFoodByAge } from "./foodExpiry";
 export {
   dispatchFishAteFoodEvents,
   subscribeFishAteFoodEvents,

--- a/src/tank/SimulationFrameBridge.tsx
+++ b/src/tank/SimulationFrameBridge.tsx
@@ -5,6 +5,7 @@ import {
   clampWallDeltaSeconds,
   dispatchFishAteFoodEvents,
   dispatchFishHungerMilestoneEvents,
+  stepExpireFoodByAge,
   stepFishKinematicsWallDelta,
   stepHerbivoreEatNearbyFood,
   stepHungerTimersWallDelta,
@@ -22,6 +23,7 @@ export function SimulationFrameBridge() {
   useFrame((_, delta) => {
     if (paused) return;
     const dt = clampWallDeltaSeconds(delta);
+    stepExpireFoodByAge(world, { simDays });
     updateHerbivoreNearestFoodTargets(world);
     stepFishKinematicsWallDelta(world, { wallDeltaSeconds: dt, simTimeDays: simDays });
     const eatEvents = stepHerbivoreEatNearbyFood(world, { paused });


### PR DESCRIPTION
Closes #180

## Summary
- Add `stepExpireFoodByAge()` in the simulation layer with a default lifetime of `0.5` simulated days.
- Run food expiry each frame before food targeting so stale flakes are removed from the authoritative world state.
- Add regression tests covering expiry at threshold, before threshold, and mixed old/new flakes.

## Verification
- `pnpm lint`

```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-180-food-expiry
> eslint .
```

- `pnpm test`

```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-180-food-expiry
> vitest run

 RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-180-food-expiry

 Test Files  19 passed (19)
      Tests  104 passed (104)
   Start at  00:21:29
   Duration  14.39s (transform 3.63s, setup 1.92s, import 6.98s, tests 1.47s, environment 85.45s)
```

- `pnpm build`

```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-180-food-expiry
> tsc -b && vite build

vite v8.0.10 building client environment for production...
transforming...✓ 69 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.50 kB │ gzip:   0.31 kB
dist/assets/index-DBW-I7j3.css     14.70 kB │ gzip:   3.54 kB
dist/assets/index-B3v8kMWc.js   1,104.21 kB │ gzip: 303.44 kB

✓ built in 424ms
[plugin builtin:vite-reporter]
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```

## Visual / Interaction Verification Tier
- Tier C (simulation logic change only; no direct UI/3D/input implementation changes in this ticket).