### PR TITLE
#183 Run snapshot autosave on day rollover

### DIFF
--- a/src/game/RunSnapshotPersistenceEffect.test.tsx
+++ b/src/game/RunSnapshotPersistenceEffect.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNewRunSimulationWorld } from "../sim/newRunWorld";
+import { type SimulationClockState } from "../sim/simulationClock";
+import { SimulationClockProvider } from "./SimulationClockProvider";
+import { RunSnapshotPersistenceEffect } from "./RunSnapshotPersistenceEffect";
+import { useSimulationClock } from "./simulationClockContext";
+import { SimulationWorldProvider } from "./SimulationWorldProvider";
+
+vi.mock("../persistence/runSnapshotStorage", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../persistence/runSnapshotStorage")>();
+  return {
+    ...actual,
+    saveRunSnapshotToLocalStorage: vi.fn(),
+  };
+});
+
+import { saveRunSnapshotToLocalStorage } from "../persistence/runSnapshotStorage";
+
+const mockedSaveRunSnapshotToLocalStorage = vi.mocked(saveRunSnapshotToLocalStorage);
+
+afterEach(() => {
+  cleanup();
+  mockedSaveRunSnapshotToLocalStorage.mockReset();
+});
+
+function RolloverHarness() {
+  const { advanceByWallDelta, togglePause } = useSimulationClock();
+  return (
+    <>
+      <RunSnapshotPersistenceEffect />
+      <button type="button" aria-label="Advance one simulation step" onClick={() => advanceByWallDelta(0.1)} />
+      <button type="button" aria-label="Toggle pause" onClick={togglePause} />
+    </>
+  );
+}
+
+function renderWithProviders(initialClockState: SimulationClockState) {
+  const world = createNewRunSimulationWorld(42);
+  return render(
+    <SimulationClockProvider initialClockState={initialClockState}>
+      <SimulationWorldProvider runSeed={42} world={world}>
+        <RolloverHarness />
+      </SimulationWorldProvider>
+    </SimulationClockProvider>,
+  );
+}
+
+describe("RunSnapshotPersistenceEffect", () => {
+  it("does not autosave before simulated day rollover", () => {
+    renderWithProviders({ paused: false, simDays: 0.95 });
+    fireEvent.click(screen.getByRole("button", { name: /advance one simulation step/i }));
+    expect(mockedSaveRunSnapshotToLocalStorage).not.toHaveBeenCalled();
+  });
+
+  it("autosaves when simulation day rolls over", () => {
+    renderWithProviders({ paused: false, simDays: 0.99 });
+    fireEvent.click(screen.getByRole("button", { name: /advance one simulation step/i }));
+    expect(mockedSaveRunSnapshotToLocalStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not autosave while paused", () => {
+    renderWithProviders({ paused: false, simDays: 0.99 });
+    fireEvent.click(screen.getByRole("button", { name: /toggle pause/i }));
+    fireEvent.click(screen.getByRole("button", { name: /advance one simulation step/i }));
+    expect(mockedSaveRunSnapshotToLocalStorage).not.toHaveBeenCalled();
+  });
+});

--- a/src/game/RunSnapshotPersistenceEffect.tsx
+++ b/src/game/RunSnapshotPersistenceEffect.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { saveRunSnapshotToLocalStorage } from "../persistence/runSnapshotStorage";
 import { useSimulationClock } from "./simulationClockContext";
 import { useSimulationWorld } from "./simulationWorldContext";
@@ -7,15 +7,25 @@ import { useSimulationWorld } from "./simulationWorldContext";
 export function RunSnapshotPersistenceEffect() {
   const { world, runSeed } = useSimulationWorld();
   const { paused, simDays } = useSimulationClock();
+  const lastPersistedDayRollover = useRef(Math.floor(simDays));
+
+  const flush = useCallback(() => {
+    saveRunSnapshotToLocalStorage({
+      world,
+      simClockState: { paused, simDays },
+      runSeed,
+    });
+  }, [world, paused, simDays, runSeed]);
 
   useEffect(() => {
-    const flush = () => {
-      saveRunSnapshotToLocalStorage({
-        world,
-        simClockState: { paused, simDays },
-        runSeed,
-      });
-    };
+    const currentDayRollover = Math.floor(simDays);
+    if (currentDayRollover > lastPersistedDayRollover.current) {
+      flush();
+      lastPersistedDayRollover.current = currentDayRollover;
+    }
+  }, [simDays, flush]);
+
+  useEffect(() => {
     window.addEventListener("pagehide", flush);
     window.addEventListener("beforeunload", flush);
     const onVisibility = () => {
@@ -27,7 +37,7 @@ export function RunSnapshotPersistenceEffect() {
       window.removeEventListener("beforeunload", flush);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [world, paused, simDays, runSeed]);
+  }, [flush]);
 
   return null;
 }


### PR DESCRIPTION
Closes #183

## Summary
- Add autosave at simulated day rollover in `RunSnapshotPersistenceEffect` by tracking integer day boundaries and flushing snapshots when the day increments.
- Keep existing page lifecycle autosave triggers (`pagehide`, `beforeunload`, `visibilitychange`) unchanged.
- Add `RunSnapshotPersistenceEffect` tests for pre-rollover, rollover, and paused behavior.

## Verification
- Tier C (logic-only persistence behavior).

### `pnpm lint`
```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-183-autosave-rollover
> eslint .
```

### `pnpm test`
```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-183-autosave-rollover
> vitest run

Test Files  19 passed (19)
Tests  104 passed (104)
```

### `pnpm build`
```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-183-autosave-rollover
> tsc -b && vite build

✓ built in 280ms
```

### Focused TDD check
```text
pnpm exec vitest run src/game/RunSnapshotPersistenceEffect.test.tsx
Test Files  1 passed (1)
Tests  3 passed (3)
```