### PR TITLE
#178 Ship playable-seed sprite pass for fish, food, and tank floor

### DIFF
--- a/docs/implementation-decisions.md
+++ b/docs/implementation-decisions.md
@@ -245,3 +245,25 @@ How it helps the game:
 - Fewer edge-case input bugs.
 - More predictable controls as UI complexity grows.
 
+### 17) Playable-seed in-tank sprite direction
+
+Decision:
+- Keep the in-tank visual pass procedural for Release 0 (R3F primitives + generated textures), with no external art pipeline dependency yet.
+- Use consistent silhouette language:
+  - fish as layered body + fin + eye forms,
+  - food as flattened flake shards,
+  - floor as a low-contrast rippled seabed texture.
+- Reserve stronger color contrast for fish and food, while floor values stay darker to preserve readability at a glance.
+
+Why:
+- The playable seed needs coherent visuals now, but introducing external sprite/atlas tooling this early would slow iteration.
+- Procedural assets keep implementation inside the existing TypeScript/R3F stack and make style adjustments cheap.
+
+How it helps the game:
+- Improves readability at default camera framing and common entity densities.
+- Gives future tickets concrete constraints for visual additions:
+  - avoid render-to-sim writes,
+  - preserve fish-vs-food silhouette contrast,
+  - keep floor/background subdued relative to gameplay entities,
+  - prefer reusable palette constants over ad-hoc per-component colors.
+

--- a/src/tank/FishMeshesFromWorld.tsx
+++ b/src/tank/FishMeshesFromWorld.tsx
@@ -1,8 +1,9 @@
 import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import type { Mesh } from "three";
+import type { Group, MeshStandardMaterial } from "three";
 import { useSimulationWorld } from "../game/simulationWorldContext";
 import { fishWithKinematics } from "../sim/world";
+import { getFishPalette } from "./tankArtDirection";
 
 /**
  * Renders fish from the authoritative ECS world. Reads transforms each frame so
@@ -10,20 +11,71 @@ import { fishWithKinematics } from "../sim/world";
  */
 export function FishMeshesFromWorld() {
   const { world } = useSimulationWorld();
-  const meshRef = useRef<Mesh>(null);
+  const rootRef = useRef<Group>(null);
+  const bodyMaterialRef = useRef<MeshStandardMaterial>(null);
+  const bellyMaterialRef = useRef<MeshStandardMaterial>(null);
+  const finMaterialRef = useRef<MeshStandardMaterial>(null);
+  const eyeMaterialRef = useRef<MeshStandardMaterial>(null);
+  const pupilMaterialRef = useRef<MeshStandardMaterial>(null);
 
   useFrame(() => {
-    const mesh = meshRef.current;
-    if (!mesh) return;
+    const root = rootRef.current;
+    if (!root) return;
     const first = [...fishWithKinematics(world)][0];
     if (!first) return;
-    mesh.position.set(first.position.x, first.position.y, first.position.z);
+    root.position.set(first.position.x, first.position.y, first.position.z);
+    if (Math.abs(first.velocity.x) > 0.001) {
+      root.rotation.y = first.velocity.x >= 0 ? 0 : Math.PI;
+    }
+
+    const palette = getFishPalette(first.fish.species, first.fish.hungerStage);
+    if (bodyMaterialRef.current) bodyMaterialRef.current.color.set(palette.body);
+    if (bellyMaterialRef.current) bellyMaterialRef.current.color.set(palette.belly);
+    if (finMaterialRef.current) finMaterialRef.current.color.set(palette.fin);
+    if (eyeMaterialRef.current) eyeMaterialRef.current.color.set(palette.eye);
+    if (pupilMaterialRef.current) pupilMaterialRef.current.color.set(palette.pupil);
   });
 
   return (
-    <mesh ref={meshRef} raycast={() => {}}>
-      <sphereGeometry args={[0.12, 20, 16]} />
-      <meshStandardMaterial color="#6eb5d9" roughness={0.45} metalness={0.15} />
-    </mesh>
+    <group ref={rootRef} raycast={() => {}}>
+      <mesh position={[0.02, 0, 0]} scale={[1.75, 0.88, 0.96]}>
+        <sphereGeometry args={[0.12, 24, 18]} />
+        <meshStandardMaterial ref={bodyMaterialRef} roughness={0.42} metalness={0.06} />
+      </mesh>
+      <mesh position={[0.03, -0.045, 0]} scale={[1.4, 0.36, 0.7]}>
+        <sphereGeometry args={[0.1, 20, 14]} />
+        <meshStandardMaterial ref={bellyMaterialRef} roughness={0.52} metalness={0.03} />
+      </mesh>
+
+      <mesh position={[-0.165, 0.002, 0]} rotation={[0, 0, Math.PI / 2]} scale={[0.85, 1.05, 0.34]}>
+        <coneGeometry args={[0.09, 0.22, 3]} />
+        <meshStandardMaterial ref={finMaterialRef} roughness={0.5} metalness={0.04} />
+      </mesh>
+      <mesh position={[-0.028, 0.102, 0]} rotation={[0, 0, Math.PI / 2]} scale={[0.4, 0.62, 0.2]}>
+        <coneGeometry args={[0.07, 0.14, 3]} />
+        <meshStandardMaterial ref={finMaterialRef} roughness={0.5} metalness={0.04} />
+      </mesh>
+      <mesh position={[0.032, -0.1, 0]} rotation={[0, 0, -Math.PI / 2]} scale={[0.36, 0.66, 0.2]}>
+        <coneGeometry args={[0.064, 0.14, 3]} />
+        <meshStandardMaterial ref={finMaterialRef} roughness={0.5} metalness={0.04} />
+      </mesh>
+
+      <mesh position={[0.13, 0.04, 0.055]} scale={[0.16, 0.16, 0.16]}>
+        <sphereGeometry args={[0.12, 14, 12]} />
+        <meshStandardMaterial ref={eyeMaterialRef} roughness={0.35} metalness={0.1} />
+      </mesh>
+      <mesh position={[0.13, 0.04, -0.055]} scale={[0.16, 0.16, 0.16]}>
+        <sphereGeometry args={[0.12, 14, 12]} />
+        <meshStandardMaterial ref={eyeMaterialRef} roughness={0.35} metalness={0.1} />
+      </mesh>
+      <mesh position={[0.148, 0.04, 0.066]} scale={[0.065, 0.065, 0.065]}>
+        <sphereGeometry args={[0.12, 10, 8]} />
+        <meshStandardMaterial ref={pupilMaterialRef} roughness={0.35} metalness={0.08} />
+      </mesh>
+      <mesh position={[0.148, 0.04, -0.066]} scale={[0.065, 0.065, 0.065]}>
+        <sphereGeometry args={[0.12, 10, 8]} />
+        <meshStandardMaterial ref={pupilMaterialRef} roughness={0.35} metalness={0.08} />
+      </mesh>
+    </group>
   );
 }

--- a/src/tank/FoodMeshesFromWorld.tsx
+++ b/src/tank/FoodMeshesFromWorld.tsx
@@ -1,15 +1,17 @@
 import { useLayoutEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import type { InstancedMesh } from "three";
-import { MeshStandardMaterial, Object3D, SphereGeometry } from "three";
+import { Color, IcosahedronGeometry, MeshStandardMaterial, Object3D } from "three";
 import { useSimulationWorld } from "../game/simulationWorldContext";
 import type { SimulationEntity } from "../sim/types";
 import { foodWithPosition } from "../sim/world";
+import { getFoodFlakeColor } from "./tankArtDirection";
 
 /** Upper bound on concurrent flakes (instancing); drop rules keep this comfortably small. */
 const MAX_FOOD_INSTANCES = 128;
 
 const dummy = new Object3D();
+const colorDummy = new Color();
 
 /**
  * Renders food flakes from ECS positions. Updates instance transforms each frame; no
@@ -20,11 +22,11 @@ export function FoodMeshesFromWorld() {
   const meshRef = useRef<InstancedMesh>(null);
 
   const [geometry, material] = useMemo(() => {
-    const geom = new SphereGeometry(0.048, 12, 10);
+    const geom = new IcosahedronGeometry(0.055, 0);
     const mat = new MeshStandardMaterial({
-      color: "#c4a060",
-      roughness: 0.7,
+      roughness: 0.58,
       metalness: 0.06,
+      vertexColors: true,
     });
     return [geom, mat] as const;
   }, []);
@@ -43,12 +45,14 @@ export function FoodMeshesFromWorld() {
     for (let i = 0; i < n; i++) {
       const p = foods[i].position;
       dummy.position.set(p.x, p.y, p.z);
-      dummy.rotation.set(0, 0, 0);
-      dummy.scale.set(1.35, 0.28, 1.05);
+      dummy.rotation.set(0.2 * ((i % 3) - 1), i * 0.45, (i % 2) * 0.4);
+      dummy.scale.set(1.6, 0.23, 1.08);
       dummy.updateMatrix();
       mesh.setMatrixAt(i, dummy.matrix);
+      mesh.setColorAt(i, colorDummy.set(getFoodFlakeColor(i)));
     }
     mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
   });
 
   return (

--- a/src/tank/TankScene.tsx
+++ b/src/tank/TankScene.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useMemo } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Color } from "three";
+import { CanvasTexture, RepeatWrapping } from "three";
 import {
   TANK_CAMERA_FAR,
   TANK_CAMERA_FOV,
@@ -12,6 +14,7 @@ import { FishMeshesFromWorld } from "./FishMeshesFromWorld";
 import { FoodMeshesFromWorld } from "./FoodMeshesFromWorld";
 import { SimulationFrameBridge } from "./SimulationFrameBridge";
 import { TankDropFoodSurface } from "./TankDropFoodSurface";
+import { createFloorTextureCanvas } from "./tankArtDirection";
 
 const sceneBackground = new Color(TANK_SCENE_BACKGROUND);
 
@@ -24,6 +27,15 @@ export type TankSceneProps = {
 export function TankScene({ className, paused = false }: TankSceneProps) {
   const frameloop = paused ? "never" : "always";
   const rootClass = [className, paused ? "pointer-events-none" : ""].filter(Boolean).join(" ");
+  const floorTexture = useMemo(() => {
+    const texture = new CanvasTexture(createFloorTextureCanvas(384));
+    texture.wrapS = RepeatWrapping;
+    texture.wrapT = RepeatWrapping;
+    texture.repeat.set(3, 2);
+    return texture;
+  }, []);
+  useEffect(() => () => floorTexture.dispose(), [floorTexture]);
+
   return (
     <div className={rootClass} data-testid="tank-scene-root">
       <Canvas
@@ -44,14 +56,16 @@ export function TankScene({ className, paused = false }: TankSceneProps) {
         <TankDropFoodSurface />
         <FoodMeshesFromWorld />
         <FishMeshesFromWorld />
-        <ambientLight intensity={0.55} />
-        <directionalLight position={[4, 6, 3]} intensity={0.85} />
+        <ambientLight intensity={0.58} />
+        <directionalLight position={[4, 6, 3]} intensity={0.9} />
+        <directionalLight position={[-3, 2.8, -4]} intensity={0.28} color="#7ec9ff" />
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, TANK_FLOOR_Y, 0]}>
           <planeGeometry args={[24, 16]} />
           <meshStandardMaterial
-            color="#142a36"
-            metalness={0.05}
-            roughness={0.95}
+            map={floorTexture}
+            color="#9ccce7"
+            metalness={0.04}
+            roughness={0.9}
           />
         </mesh>
       </Canvas>

--- a/src/tank/tankArtDirection.test.ts
+++ b/src/tank/tankArtDirection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { createFloorTextureCanvas, getFishPalette, getFoodFlakeColor } from "./tankArtDirection";
+
+describe("getFishPalette", () => {
+  test("uses species palette as baseline", () => {
+    const herbivore = getFishPalette({ kind: "herbivore" }, "healthy");
+    const carnivore = getFishPalette({ kind: "carnivore" }, "healthy");
+    expect(herbivore.body).toBe("#6bc0dd");
+    expect(carnivore.body).toBe("#d67667");
+  });
+
+  test("darkens fish colors as hunger worsens", () => {
+    const healthy = getFishPalette({ kind: "herbivore" }, "healthy");
+    const starving = getFishPalette({ kind: "herbivore" }, "starving");
+    expect(starving.body).not.toBe(healthy.body);
+    expect(starving.fin).not.toBe(healthy.fin);
+  });
+});
+
+describe("getFoodFlakeColor", () => {
+  test("cycles through deterministic color choices", () => {
+    expect(getFoodFlakeColor(0)).toBe("#dcb775");
+    expect(getFoodFlakeColor(3)).toBe("#be8850");
+    expect(getFoodFlakeColor(4)).toBe("#dcb775");
+  });
+});
+
+describe("createFloorTextureCanvas", () => {
+  test("creates a square canvas with requested size", () => {
+    const canvas = createFloorTextureCanvas(192);
+    expect(canvas.width).toBe(192);
+    expect(canvas.height).toBe(192);
+  });
+});

--- a/src/tank/tankArtDirection.ts
+++ b/src/tank/tankArtDirection.ts
@@ -1,0 +1,105 @@
+import type { FishHungerStage, FishSpeciesTag } from "../sim/types";
+
+type FishPalette = {
+  body: string;
+  belly: string;
+  fin: string;
+  eye: string;
+  pupil: string;
+};
+
+type FloorPalette = {
+  deep: string;
+  mid: string;
+  sand: string;
+  highlight: string;
+};
+
+const HERBIVORE_PALETTE: FishPalette = {
+  body: "#6bc0dd",
+  belly: "#d6f1fb",
+  fin: "#4f97bf",
+  eye: "#f9fcff",
+  pupil: "#0f1d2a",
+};
+
+const CARNIVORE_PALETTE: FishPalette = {
+  body: "#d67667",
+  belly: "#f9dbd6",
+  fin: "#af4e44",
+  eye: "#fff4ef",
+  pupil: "#2e110e",
+};
+
+const HUNGER_TINT: Record<FishHungerStage, number> = {
+  healthy: 1,
+  hungry: 0.88,
+  starving: 0.74,
+};
+
+export const FOOD_FLAKE_COLORS = ["#dcb775", "#cd9b54", "#e4c990", "#be8850"] as const;
+
+export const FLOOR_PALETTE: FloorPalette = {
+  deep: "#0f1f2a",
+  mid: "#193647",
+  sand: "#21445d",
+  highlight: "#2f627f",
+};
+
+export function getFishPalette(species: FishSpeciesTag, hunger: FishHungerStage): FishPalette {
+  const base = species.kind === "carnivore" ? CARNIVORE_PALETTE : HERBIVORE_PALETTE;
+  const tint = HUNGER_TINT[hunger];
+  return {
+    ...base,
+    body: multiplyHex(base.body, tint),
+    fin: multiplyHex(base.fin, tint),
+    belly: multiplyHex(base.belly, Math.min(1, tint + 0.06)),
+  };
+}
+
+export function getFoodFlakeColor(index: number): string {
+  return FOOD_FLAKE_COLORS[index % FOOD_FLAKE_COLORS.length];
+}
+
+export function createFloorTextureCanvas(size = 256): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext("2d");
+  if (!context) return canvas;
+
+  const gradient = context.createLinearGradient(0, 0, 0, size);
+  gradient.addColorStop(0, FLOOR_PALETTE.deep);
+  gradient.addColorStop(0.52, FLOOR_PALETTE.mid);
+  gradient.addColorStop(1, FLOOR_PALETTE.sand);
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, size, size);
+
+  context.strokeStyle = FLOOR_PALETTE.highlight;
+  context.globalAlpha = 0.12;
+  context.lineWidth = Math.max(1, size * 0.012);
+
+  const bandStep = Math.max(14, Math.floor(size * 0.08));
+  for (let y = bandStep; y < size; y += bandStep) {
+    context.beginPath();
+    context.moveTo(0, y);
+    context.bezierCurveTo(size * 0.28, y - 4, size * 0.72, y + 4, size, y);
+    context.stroke();
+  }
+
+  context.globalAlpha = 1;
+  return canvas;
+}
+
+function multiplyHex(hex: string, multiplier: number): string {
+  const clean = hex.replace("#", "");
+  const int = Number.parseInt(clean, 16);
+  const r = Math.min(255, Math.max(0, Math.round(((int >> 16) & 0xff) * multiplier)));
+  const g = Math.min(255, Math.max(0, Math.round(((int >> 8) & 0xff) * multiplier)));
+  const b = Math.min(255, Math.max(0, Math.round((int & 0xff) * multiplier)));
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function toHex(value: number): string {
+  return value.toString(16).padStart(2, "0");
+}

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -9,3 +9,11 @@ class ResizeObserverStub {
 
 globalThis.ResizeObserver =
   globalThis.ResizeObserver ?? ResizeObserverStub;
+
+// jsdom logs noisy "Not implemented" warnings for 2D canvas contexts.
+if (typeof HTMLCanvasElement !== "undefined") {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: () => null,
+  });
+}


### PR DESCRIPTION
## Linked Issue
- Closes #178

## Summary
- Replaced placeholder fish sphere with a layered procedural fish silhouette (body, belly, fins, eyes) driven by simulation state for species/hunger palette.
- Replaced food sphere flakes with flattened instanced flake shards and a deterministic warm palette for better at-a-glance distinction.
- Added a procedural floor texture treatment and documented sprite/art constraints in `docs/implementation-decisions.md` for follow-on visual work.

## Verification
### `pnpm lint`
```text
> the-aquarium@0.0.0 lint /Users/michael/Documents/the-aquarium/.worktrees/issue-178-sprite-pass
> eslint .
```

### `pnpm test`
```text
> the-aquarium@0.0.0 test /Users/michael/Documents/the-aquarium/.worktrees/issue-178-sprite-pass
> vitest run

RUN  v4.1.5 /Users/michael/Documents/the-aquarium/.worktrees/issue-178-sprite-pass

Test Files  19 passed (19)
Tests  105 passed (105)
Duration  15.06s
```

### `pnpm build`
```text
> the-aquarium@0.0.0 build /Users/michael/Documents/the-aquarium/.worktrees/issue-178-sprite-pass
> tsc -b && vite build

vite v8.0.10 building client environment for production...
✓ built in 478ms
(!) Some chunks are larger than 500 kB after minification.
```

## Visual / Interaction Verification
- Tier: **B** (Browser MCP unavailable—manual only)
- Tested URL: `http://127.0.0.1:4178/`
- Viewports: `1200x800`, `375x667`

Checklist (unchecked = failed verification):
- [ ] Initial render observed — **FAIL** (agent runtime has no interactive browser access)
- [ ] Primary interaction (click tank to drop food) — **FAIL** (agent runtime has no interactive browser access)
- [ ] Control interaction (pause/resume) — **FAIL** (agent runtime has no interactive browser access)
- [ ] Resize behavior check — **FAIL** (agent runtime has no interactive browser access)

## Notes
- Dev server started successfully on `http://127.0.0.1:4178/` for manual verification and then stopped.